### PR TITLE
🐛 Add name to database

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
     applicationId = "br.com.colman.petals"
     minSdk = 21
     targetSdk = 30
-    versionCode = 3001
-    versionName = "3.0.1"
+    versionCode = 3002
+    versionName = "3.0.2"
 
     testApplicationId = "$applicationId.test"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
@@ -60,6 +60,6 @@ private val AndroidModule = module {
 }
 
 private val SqlDelightModule = module {
-  single<SqlDriver> { AndroidSqliteDriver(Database.Schema, get()) }
+  single<SqlDriver> { AndroidSqliteDriver(Database.Schema, get(), "Database") }
   single { Database(get()) }
 }

--- a/fastlane/metadata/android/en-US/changelogs/3002.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3002.txt
@@ -1,0 +1,1 @@
+- Replaced database backend to a FLOSS alternative

--- a/fastlane/metadata/android/pt-BR/changelogs/3002.txt
+++ b/fastlane/metadata/android/pt-BR/changelogs/3002.txt
@@ -1,0 +1,1 @@
+- Modifica a forma de armazenamento de dados para uma alternativa livre


### PR DESCRIPTION
When assuming the default value, null, as the database name, SQLDelight
implicitly assumes it's an InMemory database, and thus won't persist
data to disk.

This commit fixes that by giving a name to the database.

Signed-off-by: Leonardo Colman Lopes <dev@leonardo.colman.com.br>