### PR TITLE
🐛 Fix edit use not working

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -211,6 +211,7 @@ java {
 
 sqldelight {
   database("Database") {
+    dialect = "sqlite:3.25"
     schemaOutputDirectory = file("src/main/sqldelight/databases")
     verifyMigrations = true
   }

--- a/app/src/main/kotlin/br/com/colman/petals/navigation/Usage.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/navigation/Usage.kt
@@ -59,7 +59,7 @@ fun Usage(
     val uses by useRepository.all().collectAsState(emptyList())
     if (uses.isNotEmpty()) {
       StatsBlocks(uses)
-      UseCards(uses, { useRepository.insert(it) }, { useRepository.delete(it) })
+      UseCards(uses, { useRepository.upsert(it) }, { useRepository.delete(it) })
     }
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/AddUseButton.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/AddUseButton.kt
@@ -37,7 +37,7 @@ fun AddUseButton(
   val lastUse by repository.getLastUse().collectAsState(null)
 
   if (openAddUseDialog) {
-    AddUseDialog(lastUse, { repository.insert(it) }) { openAddUseDialog = false }
+    AddUseDialog(lastUse, { repository.upsert(it) }) { openAddUseDialog = false }
   }
 
   if (openConfirmAddUseDialog) {

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/UseImporter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/UseImporter.kt
@@ -31,6 +31,6 @@ class UseImporter(
       }
     }.mapNotNull { it.getOrNull() }
 
-    useRepository.insertAll(uses)
+    useRepository.upsertAll(uses)
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/repository/UseRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/repository/UseRepository.kt
@@ -15,13 +15,13 @@ class UseRepository(
   private val useQueries: UseQueries
 ) {
 
-  fun insertAll(uses: Iterable<Use>) {
-    uses.forEach(::insert)
+  fun upsertAll(uses: Iterable<Use>) {
+    uses.forEach(::upsert)
   }
 
-  fun insert(use: Use) {
+  fun upsert(use: Use) {
     Timber.d("Adding use: $use")
-    useQueries.insert(use.toEntity())
+    useQueries.upsert(use.toEntity())
   }
 
   fun getLastUse() = useQueries.selectLast().asFlow().mapToOneOrNull().map { it?.toUse() }

--- a/app/src/main/sqldelight/br/com/colman/petals/Use.sq
+++ b/app/src/main/sqldelight/br/com/colman/petals/Use.sq
@@ -5,8 +5,11 @@ CREATE TABLE Use(
     id TEXT PRIMARY KEY
 );
 
-insert:
-INSERT INTO Use(date, amount_grams, cost_per_gram, id) VALUES ?;
+upsert:
+INSERT INTO Use(date, amount_grams, cost_per_gram, id) VALUES ?
+ON CONFLICT (id) DO UPDATE SET date = excluded.date,
+ amount_grams = excluded.amount_grams,
+  cost_per_gram = excluded.cost_per_gram;
 
 selectLast:
 SELECT * FROM Use ORDER BY date DESC LIMIT 1;

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/UseImporterSpec.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/UseImporterSpec.kt
@@ -65,7 +65,7 @@ class UseImporterSpec : FunSpec({
 
       shouldNotThrowAny {
         verify {
-          useRepository.insertAll(uses)
+          useRepository.upsertAll(uses)
         }
       }
     }
@@ -78,7 +78,7 @@ class UseImporterSpec : FunSpec({
 
       shouldNotThrowAny {
         verify {
-          useRepository.insertAll(uses)
+          useRepository.upsertAll(uses)
         }
       }
     }
@@ -90,7 +90,7 @@ class UseImporterSpec : FunSpec({
 
       shouldNotThrowAny {
         verify {
-          useRepository.insertAll(emptyList())
+          useRepository.upsertAll(emptyList())
         }
       }
     }


### PR DESCRIPTION
After the database migration on release 3.0.0, the insert stopped behaving like an Upsert, as it used to in Objectbox.

This commit changes the insert in the database to be an Upsert, as specified in https://www.sqlite.org/lang_UPSERT.html. The changes were made to file Use.sq.

This behavior is only to the database, and thus a single test was added to UseRepositoryTest to ensure it. All other files changed are collateral of the rename refactor.

Closes #124

Signed-off-by: Leonardo Colman Lopes <dev@leonardo.colman.com.br>