### PR TITLE
Fix bug preventing some devices from inserting Use

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -191,6 +191,7 @@ dependencies {
   implementation(libs.sqldelight.android.driver)
   implementation(libs.sqldelight.coroutines.extensions)
   testImplementation(libs.sqldelight.sqlite.driver)
+  implementation(libs.requery.sqlite)
 
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
     applicationId = "br.com.colman.petals"
     minSdk = 21
     targetSdk = 30
-    versionCode = 3103
-    versionName = "3.1.3"
+    versionCode = 3200
+    versionName = "3.2.0"
 
     testApplicationId = "$applicationId.test"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
@@ -24,6 +24,7 @@ import br.com.colman.petals.BuildConfig.DEBUG
 import br.com.colman.petals.use.io.IoModules
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import com.squareup.sqldelight.db.SqlDriver
+import io.requery.android.database.sqlite.RequerySQLiteOpenHelperFactory
 import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.compose.get
 import org.koin.core.Koin
@@ -61,7 +62,7 @@ private val AndroidModule = module {
 
 private val SqlDelightModule = module {
   single<SqlDriver> {
-    AndroidSqliteDriver(Database.Schema, get(), "Database")
+    AndroidSqliteDriver(Database.Schema, get(), "Database", RequerySQLiteOpenHelperFactory())
   }
   single { Database(get()) }
 }

--- a/fastlane/metadata/android/en-US/changelogs/3200.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3200.txt
@@ -1,0 +1,2 @@
+- Fix bug preventing some devices from inserting Use
+- Added translations from Weblate

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ timber = "com.jakewharton.timber:timber:5.0.1"
 sqldelight-android-driver = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-coroutines-extensions = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelight-sqlite-driver = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqldelight" }
+requery-sqlite = "com.github.requery:sqlite-android:3.39.2"
 
 [bundles]
 androidx-test = [


### PR DESCRIPTION
With the upsert syntax, devices not supporting SQLite 3.22+ won't work with the upsert syntax.

https://stackoverflow.com/questions/2421189/version-of-sqlite-used-in-android

This reduces by a lot the number of supported devices. This commit fixes that