### PR TITLE
Bump targetSDK to version 33

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
   defaultConfig {
     applicationId = "br.com.colman.petals"
     minSdk = 21
-    targetSdk = 30
+    targetSdk = 33
     versionCode = 3200
     versionName = "3.2.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
     applicationId = "br.com.colman.petals"
     minSdk = 21
     targetSdk = 33
-    versionCode = 3200
-    versionName = "3.2.0"
+    versionCode = 3201
+    versionName = "3.2.1"
 
     testApplicationId = "$applicationId.test"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Google forbids apps with target sdk  <= 31. This commit increments that
version in order to fix it.

Fixes #137