### PR TITLE
Fix timer misbehaving when adding uses in the future

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
     applicationId = "br.com.colman.petals"
     minSdk = 21
     targetSdk = 33
-    versionCode = 3203
-    versionName = "3.2.3"
+    versionCode = 3204
+    versionName = "3.2.4"
 
     testApplicationId = "$applicationId.test"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/sqldelight/br/com/colman/petals/Use.sq
+++ b/app/src/main/sqldelight/br/com/colman/petals/Use.sq
@@ -12,7 +12,7 @@ ON CONFLICT (id) DO UPDATE SET date = excluded.date,
   cost_per_gram = excluded.cost_per_gram;
 
 selectLast:
-SELECT * FROM Use ORDER BY date DESC LIMIT 1;
+SELECT * FROM Use WHERE datetime(date) <= datetime('now', 'localtime') ORDER BY date DESC LIMIT 1;
 
 selectAll:
 SELECT * FROM Use;

--- a/fastlane/metadata/android/en-US/changelogs/3204.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3204.txt
@@ -1,0 +1,1 @@
+- Fix timer counting down from the future when adding an use in the future


### PR DESCRIPTION
This commit changes the logic on Use.sq to only include uses in the past
 as eligible for being the last use.

 Fixes #131