### PR TITLE
💄 Add colors to UsePerDayOfWeek

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/statistics/graph/UsePerDayOfWeek.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/statistics/graph/UsePerDayOfWeek.kt
@@ -63,11 +63,17 @@ fun UsePerDayOfWeekGraph(uses: List<Use>) {
         axisMaximum = 7.0f
         granularity = 1.0f
         labelCount = 7
+
+        textColor = colors.primary.toArgb()
+        axisLineColor = colors.primary.toArgb()
       }
 
       chart.axisLeft.isEnabled = false
       chart.axisRight.apply {
         axisMinimum = 0f
+
+        textColor = colors.primary.toArgb()
+        axisLineColor = colors.primary.toArgb()
       }
 
       chart.data = BarData(gramsData).apply {


### PR DESCRIPTION
As it was, dark mode rendered every text black, and it was invisible. This commit adds the coloring following what was used in UsePerHourGraph

Closes #177