### PR TITLE
🚸 Improve Time Format Options

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
@@ -22,7 +22,7 @@ class SettingsRepository(
     "MM-dd-yyyy"
   )
   val dateFormat = datastore.data.map { it[DateFormat] ?: dateFormatList.first() }
-  val timeFormatList = listOf("HH-mm", "HH:mm", "mm-HH", "mm:HH")
+  val timeFormatList = listOf("HH:mm", "KK:mm a", "HH:mm:ss", "KK:mm:ss a")
   val timeFormat = datastore.data.map { it[TimeFormat] ?: timeFormatList.first() }
 
   fun setCurrencyIcon(value: String): Unit = runBlocking {

--- a/app/src/test/kotlin/br/com/colman/petals/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/settings/SettingsRepositoryTest.kt
@@ -57,8 +57,8 @@ class SettingsRepositoryTest : FunSpec({
     datastore.data.first().get(DateFormat) shouldBe "yyyy/MM/dd"
   }
 
-  test("Defaults time format to HH-mm") {
-    target.timeFormat.first() shouldBe "HH-mm"
+  test("Defaults time format to HH:mm") {
+    target.timeFormat.first() shouldBe "HH:mm"
   }
 
   test("Changes time format to the specified one") {


### PR DESCRIPTION
Changed the options to the following:
1.HH:mm
2.KK:mm a
3.HH:mm:ss
4.KK:mm:ss a

This closes the issue https://github.com/LeoColman/Petals/issues/267 .
Fixed the unit test accordingly.