### PR TITLE
Add setting to specify precision on numbers #292

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
@@ -3,6 +3,7 @@ package br.com.colman.petals.settings
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -30,6 +31,8 @@ class SettingsRepository(
   val hitTimerMillisecondsEnabled = datastore.data.map {
     it[HitTimerMillisecondsEnabled] ?: hitTimerMillisecondsEnabledList.first()
   }
+  val decimalPrecisionList = listOf(0, 1, 2, 3)
+  val decimalPrecision = datastore.data.map { it[DecimalPrecision] ?: decimalPrecisionList[2] }
 
   fun setCurrencyIcon(value: String): Unit = runBlocking {
     datastore.edit { it[CurrencyIcon] = value }
@@ -51,6 +54,10 @@ class SettingsRepository(
     datastore.edit { it[HitTimerMillisecondsEnabled] = value }
   }
 
+  fun setDecimalPrecision(value: Int): Unit = runBlocking {
+    datastore.edit { it[DecimalPrecision] = value }
+  }
+
   val pin: Flow<String?>
     get() = datastore.data.map { it[Pin] }
 
@@ -67,5 +74,6 @@ class SettingsRepository(
     val Pin = stringPreferencesKey("pin")
     val MillisecondsEnabled = stringPreferencesKey("milliseconds_enabled")
     val HitTimerMillisecondsEnabled = stringPreferencesKey("hit_timer_milliseconds_enabled")
+    val DecimalPrecision = intPreferencesKey("decimal_precision")
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
@@ -41,6 +41,7 @@ import androidx.core.content.ContextCompat
 import br.com.colman.petals.R.string.app_pin
 import br.com.colman.petals.R.string.currency_icon
 import br.com.colman.petals.R.string.date_format_label
+import br.com.colman.petals.R.string.decimal_precision
 import br.com.colman.petals.R.string.enable_or_disable_milliseconds_bar_on_home_page
 import br.com.colman.petals.R.string.enable_or_disable_milliseconds_on_hit_timer_page
 import br.com.colman.petals.R.string.hit_timer_milliseconds_enabled
@@ -54,10 +55,13 @@ import br.com.colman.petals.R.string.share_app_message
 import br.com.colman.petals.R.string.share_app_title
 import br.com.colman.petals.R.string.time_format_label
 import br.com.colman.petals.R.string.what_date_format_should_be_used
+import br.com.colman.petals.R.string.what_decimal_precision_should_be_used
 import br.com.colman.petals.R.string.what_icon_should_be_used_for_currency
 import br.com.colman.petals.R.string.what_time_format_should_be_used
+
 import compose.icons.TablerIcons
 import compose.icons.tablericons.BrandGithub
+import compose.icons.tablericons.Calculator
 import compose.icons.tablericons.Calendar
 import compose.icons.tablericons.Cash
 import compose.icons.tablericons.CircleOff
@@ -84,6 +88,9 @@ fun SettingsView(settingsRepository: SettingsRepository) {
   val currentHitTimerMillisecondsEnabled by settingsRepository.hitTimerMillisecondsEnabled.collectAsState(
     hitTimerMillisecondsEnabledList[0]
   )
+  val setDecimalPrecision = settingsRepository::setDecimalPrecision
+  val decimalPrecisionList = settingsRepository.decimalPrecisionList
+  val currentDecimalPrecision by settingsRepository.decimalPrecision.collectAsState(decimalPrecisionList[2])
 
   Column(Modifier.verticalScroll(rememberScrollState())) {
     CurrencyListItem(currentCurrency, setCurrency)
@@ -97,6 +104,7 @@ fun SettingsView(settingsRepository: SettingsRepository) {
       hitTimerMillisecondsEnabledList,
       setHitTimerMillisecondsEnabled
     )
+    PrecisionListItem(currentDecimalPrecision, decimalPrecisionList, setDecimalPrecision)
     ShareApp()
   }
 }
@@ -254,6 +262,29 @@ fun HitTimerMillisecondsEnabledListItem(
       hitTimerMillisecondsEnabledList,
       setHitTimerMillisecondsEnabled
     ) { shouldShowDialog = false }
+  }
+}
+
+@Preview
+@Composable
+fun PrecisionListItem(
+  decimalPrecision: Int = 2,
+  decimalPrecisionList: List<Int> = listOf(),
+  setDecimalPrecision: (Int) -> Unit = {}
+) {
+  var shouldShowDialog by remember { mutableStateOf(false) }
+
+  ListItem(
+    modifier = Modifier.clickable { shouldShowDialog = true },
+    icon = { Icon(TablerIcons.Calculator, null, Modifier.size(42.dp)) },
+
+    secondaryText = { Text(stringResource(what_decimal_precision_should_be_used)) }
+  ) {
+    Text(stringResource(decimal_precision))
+  }
+
+  if (shouldShowDialog) {
+    PrecisionDialog(decimalPrecision, decimalPrecisionList, setDecimalPrecision) { shouldShowDialog = false }
   }
 }
 
@@ -564,6 +595,63 @@ private fun HitTimerMillisecondsEnabledDialog(
         Modifier
           .padding(8.dp)
           .clickable { setHitTimerMillisecondsEnabled(hitTimerMillisecondsEnabled); onDismiss() }
+      )
+    }
+  )
+}
+
+@Preview
+@Composable
+private fun PrecisionDialog(
+  decimalPrecision: Int = 2,
+  decimalPrecisionList: List<Int> = listOf(),
+  setDecimalPrecision: (Int) -> Unit = {},
+  onDismiss: () -> Unit = {},
+) {
+  var decimalPrecision by remember { mutableStateOf(decimalPrecision) }
+  var expanded by remember { mutableStateOf(false) }
+
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    text = {
+      ExposedDropdownMenuBox(
+        expanded = false,
+        onExpandedChange = { expanded = !expanded }
+      ) {
+        TextField(
+          value = decimalPrecision.toString(),
+          onValueChange = {},
+          readOnly = true,
+          label = { Text(text = stringResource(decimal_precision)) },
+          trailingIcon = {
+            ExposedDropdownMenuDefaults.TrailingIcon(
+              expanded = expanded
+            )
+          },
+          colors = ExposedDropdownMenuDefaults.textFieldColors()
+        )
+
+        ExposedDropdownMenu(
+          expanded = expanded,
+          onDismissRequest = { expanded = false }
+        ) {
+          decimalPrecisionList.forEach { selectedOption ->
+            DropdownMenuItem(onClick = {
+              decimalPrecision = selectedOption
+              expanded = false
+            }) {
+              Text(text = selectedOption.toString())
+            }
+          }
+        }
+      }
+    },
+    confirmButton = {
+      Text(
+        stringResource(ok),
+        Modifier
+          .padding(8.dp)
+          .clickable { setDecimalPrecision(decimalPrecision); onDismiss() }
       )
     }
   )

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
@@ -58,7 +58,6 @@ import br.com.colman.petals.R.string.what_date_format_should_be_used
 import br.com.colman.petals.R.string.what_decimal_precision_should_be_used
 import br.com.colman.petals.R.string.what_icon_should_be_used_for_currency
 import br.com.colman.petals.R.string.what_time_format_should_be_used
-
 import compose.icons.TablerIcons
 import compose.icons.tablericons.BrandGithub
 import compose.icons.tablericons.Calculator

--- a/app/src/main/kotlin/br/com/colman/petals/statistics/card/AverageUseCard.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/statistics/card/AverageUseCard.kt
@@ -139,7 +139,7 @@ private fun AverageListItem(label: String, grams: BigDecimal, cost: BigDecimal, 
   Row {
     Text(stringResource(average_per, label), Modifier.weight(0.4f))
     Text(stringResource(amount_grams_short, grams), Modifier.weight(0.6f / 3f))
-    Text(currencyIcon + cost, Modifier.weight(0.6f / 3f))
+    Text(currencyIcon + "%.2f".format(cost), Modifier.weight(0.6f / 3f))
     Text(pluralResource(amount_uses, uses.toInt(), uses.setScale(2, RoundingMode.CEILING)))
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/UseBlock.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/UseBlock.kt
@@ -88,11 +88,14 @@ private fun UseBlock(title: String, uses: List<Use>) {
   var totalGrams by remember { mutableStateOf("") }
   var totalCost by remember { mutableStateOf("") }
 
+  val settingsRepository = get<SettingsRepository>()
+  val decimalPrecision by settingsRepository.decimalPrecision.collectAsState(settingsRepository.decimalPrecisionList[2])
+
   // HALF_UP is necessary because the default rounding
   // mode is "throw an exception".
   LaunchedEffect(uses) {
-    totalGrams = uses.sumOf { it.amountGrams }.setScale(3, HALF_UP).toString()
-    totalCost = uses.sumOf { it.costPerGram * it.amountGrams }.setScale(3, HALF_UP).toString()
+    totalGrams = uses.sumOf { it.amountGrams }.setScale(decimalPrecision, HALF_UP).toString()
+    totalCost = uses.sumOf { it.costPerGram * it.amountGrams }.setScale(decimalPrecision, HALF_UP).toString()
   }
 
   UseBlock(title, totalGrams, totalCost)

--- a/app/src/main/kotlin/br/com/colman/petals/use/UseCard.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/UseCard.kt
@@ -85,6 +85,7 @@ fun UseCard(use: Use = Use(), onEditUse: (Use) -> Unit = { }, onDeleteUse: (Use)
   val timeFormat by settingsRepository.timeFormat.collectAsState(settingsRepository.timeFormatList[0])
   val timeString = date.format(ofPattern(timeFormat))
   val currencySymbol by get<SettingsRepository>().currencyIcon.collectAsState("$")
+  val decimalPrecision by settingsRepository.decimalPrecision.collectAsState(settingsRepository.decimalPrecisionList[2])
 
   Card(
     Modifier
@@ -106,19 +107,19 @@ fun UseCard(use: Use = Use(), onEditUse: (Use) -> Unit = { }, onDeleteUse: (Use)
 
         Row(Modifier, spacedBy(8.dp), CenterVertically) {
           Icon(TablerIcons.Cash, null)
-          val costPerGramString = costPerGram.setScale(3, HALF_UP).toString()
+          val costPerGramString = costPerGram.setScale(decimalPrecision, HALF_UP).toString()
           Text("$currencySymbol " + stringResource(cost_per_gram, costPerGramString))
         }
 
         Row(Modifier, spacedBy(8.dp), CenterVertically) {
           Icon(TablerIcons.Scale, null)
-          val amountGramsString = amountGrams.setScale(3, HALF_UP).toString()
+          val amountGramsString = amountGrams.setScale(decimalPrecision, HALF_UP).toString()
           Text(stringResource(amount_grams, amountGramsString))
         }
 
         Row(Modifier, spacedBy(8.dp), CenterVertically) {
           Icon(TablerIcons.ReportMoney, null)
-          val total = (amountGrams * costPerGram).setScale(3, HALF_UP)
+          val total = (amountGrams * costPerGram).setScale(decimalPrecision, HALF_UP)
           Text("$currencySymbol " + stringResource(total_spent, total))
         }
       }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -123,7 +123,9 @@
     <string name="password_description">For extra privacy you can setup a password to access the app. Setting an empty password removes it. ATTENTION! It\'s not possible to recover a set password</string>
     <string name="pin_main_screen">This application is password protected. Enter the right password to proceed.</string>
     <string name="milliseconds_enabled">Toggle Milliseconds Bar</string>
-    <string name="enable_or_disable_milliseconds_bar_on_home_page">Enable or disable milliseconds bar on home page</string>
+    <string name="enable_or_disable_milliseconds_bar_on_home_page">Enable or disable milliseconds bar on Usage page</string>
     <string name="hit_timer_milliseconds_enabled">Toggle Milliseconds on Hit Timer Page</string>
     <string name="enable_or_disable_milliseconds_on_hit_timer_page">Enable or disable milliseconds on Hit Timer page</string>
+    <string name="decimal_precision">Decimal Precision</string>
+    <string name="what_decimal_precision_should_be_used">What decimal precision should be displayed on Usage page</string>
 </resources>


### PR DESCRIPTION
Should solve #292 adding the option to select 0-3 decimal places to be displayed.
Currently settings page does not scroll #313

Also changed decimals displayed on Stats page average use card from 4 to 2 on the cost.