### PR TITLE
Add date to exported fileName

### DIFF
--- a/app/src/androidTest/kotlin/br/com/colman/petals/use/io/FileWriterTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/use/io/FileWriterTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.file.shouldNotExist
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import java.io.File
+import java.time.LocalDate
 
 class FileWriterTest : FunSpec({
 
@@ -39,6 +40,6 @@ class FileWriterTest : FunSpec({
   test("Uses PetalsExport.csv as the default file name") {
     val uri = target.write("xxx")
 
-    uri.path shouldEndWith "PetalsExport.csv"
+    uri.path shouldEndWith "PetalsExport-${LocalDate.now()}.csv"
   }
 })

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/FileWriter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/FileWriter.kt
@@ -5,11 +5,14 @@ import android.net.Uri
 import androidx.core.content.FileProvider.getUriForFile
 import br.com.colman.petals.BuildConfig.APPLICATION_ID
 import java.io.File
+import java.time.LocalDate
 
 class FileWriter(private val context: Context) {
 
-  private val fileName = "PetalsExport.csv"
-
+  private fun generateFileName(): String {
+   val date = LocalDate.now()
+   return "PetalsExport-$date.csv"
+  }
   private val exportsDir by lazy {
     File(context.filesDir, "exports").apply {
       if (!exists()) mkdirs()
@@ -22,5 +25,5 @@ class FileWriter(private val context: Context) {
     return getUriForFile(context, APPLICATION_ID, exportedFile)
   }
 
-  private fun createFile(content: String) = File(exportsDir, fileName).apply { writeText(content) }
+  private fun createFile(content: String) = File(exportsDir, generateFileName()).apply { writeText(content) }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/FileWriter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/FileWriter.kt
@@ -10,8 +10,8 @@ import java.time.LocalDate
 class FileWriter(private val context: Context) {
 
   private fun generateFileName(): String {
-   val date = LocalDate.now()
-   return "PetalsExport-$date.csv"
+    val date = LocalDate.now()
+    return "PetalsExport-$date.csv"
   }
   private val exportsDir by lazy {
     File(context.filesDir, "exports").apply {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-assertions-android = { module = "br.com.colman:kotest-assertions-android", version = "1.0.0" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
-kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.0.0" }
+kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.1.0" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
 kotest-extensions-now = { module = "io.kotest:kotest-extensions-now", version.ref = "kotest" }


### PR DESCRIPTION
This changes the hardcoded "PetalsExport.csv" fileName to a unique one that identifies the date it was saved

Example: "PetalsExport-2023-09-25.csv"