### PR TITLE
⬆ Update github-workflows-kt monorepo to v1.10.0

### DIFF
--- a/.github/workflows/build.main.kts
+++ b/.github/workflows/build.main.kts
@@ -1,9 +1,10 @@
 #!/usr/bin/env kotlin
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.8.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.10.0")
 @file:Import("generated/actions/checkout.kt")
 @file:Import("generated/actions/setup-java.kt")
 @file:Import("generated/gradle/gradle-build-action.kt")
 
+import io.github.typesafegithub.workflows.annotations.ExperimentalClientSideBindings
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
@@ -14,6 +15,7 @@ import io.github.typesafegithub.workflows.yaml.writeToFile
 
 val GPG_KEY by Contexts.secrets
 
+@OptIn(ExperimentalClientSideBindings::class)
 workflow(
   name = "Build Universal APK",
   on = listOf(Push(), PullRequest()),

--- a/.github/workflows/dependency-license-analysis.main.kts
+++ b/.github/workflows/dependency-license-analysis.main.kts
@@ -1,9 +1,10 @@
 #!/usr/bin/env kotlin
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.8.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.10.0")
 @file:Import("generated/actions/checkout.kt")
 @file:Import("generated/actions/setup-java.kt")
 @file:Import("generated/gradle/gradle-build-action.kt")
 
+import io.github.typesafegithub.workflows.annotations.ExperimentalClientSideBindings
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
@@ -11,6 +12,7 @@ import io.github.typesafegithub.workflows.dsl.workflow
 import io.github.typesafegithub.workflows.yaml.writeToFile
 
 
+@OptIn(ExperimentalClientSideBindings::class)
 workflow(
   name = "Dependency License Analysis",
   on = listOf(Push(), PullRequest()),

--- a/.github/workflows/generate-action-bindings.main.kts
+++ b/.github/workflows/generate-action-bindings.main.kts
@@ -1,7 +1,9 @@
 #!/usr/bin/env kotlin
 
-@file:DependsOn("io.github.typesafegithub:action-binding-generator:1.8.0")
+@file:DependsOn("io.github.typesafegithub:action-binding-generator:1.10.0")
 
-import io.github.typesafegithub.workflows.actionbindinggenerator.generateActionBindings
+import io.github.typesafegithub.workflows.actionbindinggenerator.annotations.ExperimentalClientSideBindings
+import io.github.typesafegithub.workflows.actionbindinggenerator.generation.generateActionBindings
 
+@OptIn(ExperimentalClientSideBindings::class)
 generateActionBindings(args, __FILE__.toPath())

--- a/.github/workflows/lint.main.kts
+++ b/.github/workflows/lint.main.kts
@@ -1,9 +1,10 @@
 #!/usr/bin/env kotlin
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.8.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.10.0")
 @file:Import("generated/actions/checkout.kt")
 @file:Import("generated/actions/setup-java.kt")
 @file:Import("generated/gradle/gradle-build-action.kt")
 
+import io.github.typesafegithub.workflows.annotations.ExperimentalClientSideBindings
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
@@ -11,6 +12,7 @@ import io.github.typesafegithub.workflows.dsl.workflow
 import io.github.typesafegithub.workflows.yaml.writeToFile
 
 
+@OptIn(ExperimentalClientSideBindings::class)
 workflow(
   name = "Lint",
   on = listOf(Push(), PullRequest()),

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -1,5 +1,5 @@
 #!/usr/bin/env kotlin
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.8.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.10.0")
 @file:Import("generated/actions/checkout.kt")
 @file:Import("generated/actions/setup-java.kt")
 @file:Import("generated/gradle/gradle-build-action.kt")
@@ -7,7 +7,7 @@
 @file:Import("generated/ruby/setup-ruby.kt")
 @file:Import("generated/softprops/action-gh-release.kt")
 
-
+import io.github.typesafegithub.workflows.annotations.ExperimentalClientSideBindings
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.triggers.Push
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
@@ -19,6 +19,7 @@ import io.github.typesafegithub.workflows.yaml.writeToFile
 val GPG_KEY by Contexts.secrets
 val GITHUB_REF_NAME by Contexts.github
 
+@OptIn(ExperimentalClientSideBindings::class)
 workflow(
   name = "Release",
   on = listOf(Push(tags = listOf("*"))),

--- a/.github/workflows/unit-tests.main.kts
+++ b/.github/workflows/unit-tests.main.kts
@@ -1,9 +1,10 @@
 #!/usr/bin/env kotlin
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.8.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:1.10.0")
 @file:Import("generated/actions/checkout.kt")
 @file:Import("generated/actions/setup-java.kt")
 @file:Import("generated/gradle/gradle-build-action.kt")
 
+import io.github.typesafegithub.workflows.annotations.ExperimentalClientSideBindings
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.PullRequest
 import io.github.typesafegithub.workflows.domain.triggers.Push
@@ -11,6 +12,7 @@ import io.github.typesafegithub.workflows.dsl.workflow
 import io.github.typesafegithub.workflows.yaml.writeToFile
 
 
+@OptIn(ExperimentalClientSideBindings::class)
 workflow(
   name = "Unit Tests",
   on = listOf(Push(), PullRequest()),


### PR DESCRIPTION
Contains adjustments for breaking changes, as described in https://github.com/typesafegithub/github-workflows-kt/releases/tag/v1.9.0.