### PR TITLE
💄 Refactor label generation in graph classes

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/statistics/graph/UsePerDayOfWeekGraph.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/statistics/graph/UsePerDayOfWeekGraph.kt
@@ -2,10 +2,8 @@ package br.com.colman.petals.statistics.graph
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import br.com.colman.petals.R
 import br.com.colman.petals.R.string
 import br.com.colman.petals.statistics.component.Period
 import br.com.colman.petals.statistics.graph.component.LineChart
@@ -56,7 +54,7 @@ fun UsePerDayOfWeekGraph(useGroups: Map<Period, List<Use>>) {
   val description = stringResource(string.grams_distribution_per_day_of_week)
   val colors = MaterialTheme.colors
   val gramsData = useGroups.map { (period, uses) ->
-    val label = pluralStringResource(R.plurals.last_x_days, period.days, period.days)
+    val label = period.label()
     createDistributionPerDayOfWeekDataset(period.days, uses, label, colors)
   }
 

--- a/app/src/main/kotlin/br/com/colman/petals/statistics/graph/UsePerHourGraph.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/statistics/graph/UsePerHourGraph.kt
@@ -1,10 +1,8 @@
 package br.com.colman.petals.statistics.graph
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import br.com.colman.petals.R.plurals.last_x_days
 import br.com.colman.petals.R.string.grams_distribution_per_hour_of_day
 import br.com.colman.petals.statistics.component.Period
 import br.com.colman.petals.statistics.graph.component.LineChart
@@ -58,7 +56,7 @@ fun UsePerHourGraphPreview2() {
 fun UsePerHourGraph(useGroups: Map<Period, List<Use>>) {
   val description = stringResource(grams_distribution_per_hour_of_day)
   val gramsData = useGroups.map { (period, uses) ->
-    val label = pluralStringResource(last_x_days, period.days, period.days)
+    val label = period.label()
     createDistributionPerHourDataset(period.days, uses, label)
   }
 


### PR DESCRIPTION
Unused imports have been removed and label generation in UsePerHourGraph
 and UsePerDayOfWeekGraph has been changed. Now, instead of using a
 pluralStringResource, the label method from Period is used, simplifying
  the code and centralizing label generation.

  Closes #521