### PR TITLE
💄 Add check to avoid 0 in durationMillisecondsDisabled

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
@@ -40,6 +40,10 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
 
   companion object {
     fun duration(millis: Long): String = DurationFormatUtils.formatDuration(millis, "ss:SSS")
-    fun durationMillisecondsDisabled(millis: Long): String = DurationFormatUtils.formatDuration(millis, "s")
+    fun durationMillisecondsDisabled(millis: Long): String = when {
+      millis > 1000 -> DurationFormatUtils.formatDuration(millis, "s")
+      millis > 0 -> "1"
+      else -> "0"
+    }
   }
 }

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
@@ -33,4 +33,10 @@ class HitTimerTest : FunSpec({
     val allResults = flow.take(300).toList()
     allResults.size shouldBeGreaterThanOrEqual (duration / 10).toInt()
   }
+
+  test("Duration with milliseconds disabled should not show 0 while there are still milliseconds") {
+    val durationMillisecondsDisabled = HitTimer.durationMillisecondsDisabled(1)
+
+    durationMillisecondsDisabled shouldBe "1"
+  }
 })


### PR DESCRIPTION
The durationMillisecondsDisabled method in HitTimer class now includes a
 conditional to prevent it from showing 0 while milliseconds are still
 present. This change will ensure more accurate time display. A matching
  test has been added in HitTimerTest.kt for verification.

  Closes #543