### PR TITLE
💄 Add check to avoid 0 in durationMillisecondsDisabled

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.time.DurationFormatUtils
 import java.time.LocalDateTime
 import java.time.LocalDateTime.now
 import java.time.temporal.ChronoUnit.MILLIS
+import java.util.Locale
 
 @Parcelize
 class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
@@ -40,6 +41,10 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
 
   companion object {
     fun duration(millis: Long): String = DurationFormatUtils.formatDuration(millis, "ss:SSS")
-    fun durationMillisecondsDisabled(millis: Long): String = DurationFormatUtils.formatDuration(millis, "s")
+    fun durationMillisecondsDisabled(millis: Long): String = when {
+      millis > 1000 -> (millis / 1000).toString()
+      millis > 0 -> "%.1f".format(Locale.US, millis / 1000.0)
+      else -> "0.0"
+    }
   }
 }

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
@@ -1,6 +1,7 @@
 package br.com.colman.petals.hittimer
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldBeMonotonicallyDecreasing
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
@@ -32,5 +33,19 @@ class HitTimerTest : FunSpec({
     target.start()
     val allResults = flow.take(300).toList()
     allResults.size shouldBeGreaterThanOrEqual (duration / 10).toInt()
+  }
+
+  context("Duration with milliseconds disabled should not show 0 while there are still milliseconds") {
+    withData(
+      nameFn = { (millis, string) -> "$millis milliseconds should be converted to $string" },
+      0L to "0.0",
+      100L to "0.1",
+      249L to "0.2",
+      250L to "0.3",
+      666L to "0.7",
+      1200L to "1"
+    ) { (millis, string) ->
+      HitTimer.durationMillisecondsDisabled(millis) shouldBe string
+    }
   }
 })


### PR DESCRIPTION
The durationMillisecondsDisabled method in HitTimer class now includes a
 conditional to prevent it from showing 0 while milliseconds are still
 present. This change will ensure more accurate time display. A matching
  test has been added in HitTimerTest.kt for verification.

  Closes #543