### PR TITLE
💄 Correct percentage notation in multi-language THC concentration str…

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -46,8 +46,8 @@
     <string name="change_period">Zeitraum ändern</string>
     <string name="grams">Gramm</string>
     <string name="grams_distribution_per_hour_of_day">Verteilung in Gramm pro Stunde des Tages</string>
-    <string name="current_thc_concentration">Aktuelle THC-Konzentration: %s %%</string>
-    <string name="thc_concentration">THC-Konzentration(%%)</string>
+    <string name="current_thc_concentration">Aktuelle THC-Konzentration: %s \%%</string>
+    <string name="thc_concentration">THC-Konzentration(%)</string>
     <string name="current_withdrawal_discomfort">Aktuelle Entzugsbeschwerden: %s</string>
     <string name="discomfort_strength">Stärke des Unbehagens</string>
     <string name="date_at_time">%1$s um %2$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -43,7 +43,7 @@
     <string name="start_date">Fecha inicio</string>
     <string name="change_period">Cambiar periodo</string>
     <string name="grams_distribution_per_hour_of_day">Distribución de gramos por hora del día</string>
-    <string name="current_thc_concentration">Concentración actual de THC: %s %%</string>
+    <string name="current_thc_concentration">Concentración actual de THC: %s \%%</string>
     <string name="current_withdrawal_discomfort">Malestar actual por la abstinencia: %s</string>
     <string name="discomfort_strength">Intensidad del malestar</string>
     <string name="day">día</string>
@@ -67,7 +67,7 @@
     <string name="hittime_source">Fuente: Azorlosa JL, Greenwald MK, Stitzer ML. Marijuana smoking: effects of varying puff volume and breathhold duration. J Pharmacol Exp Ther. 1995. Feb;272(2):560–9. PMID: 7853169.</string>
     <string name="this_year">Este año</string>
     <string name="grams">Gramos</string>
-    <string name="thc_concentration">Concentración de THC (%%)</string>
+    <string name="thc_concentration">Concentración de THC (%)</string>
     <string name="average_per">Promedio por %s</string>
     <string name="vibrate_on_timer_end">Vibrar al finalizar temporizador</string>
     <plurals name="amount_uses">

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -67,8 +67,8 @@
     <string name="change_period">Mudar período</string>
     <string name="grams">Gramas</string>
     <string name="grams_distribution_per_hour_of_day">Distribuição de gramas por hora do dia</string>
-    <string name="current_thc_concentration">Concentração atual de THC: %s %%</string>
-    <string name="thc_concentration">Concentração de THC (%%)</string>
+    <string name="current_thc_concentration">Concentração atual de THC: %s \%%</string>
+    <string name="thc_concentration">Concentração de THC (%)</string>
     <string name="current_withdrawal_discomfort">Desconforto atual de abstinência: %s</string>
     <string name="discomfort_strength">Intensidade de desconforto</string>
     <string name="date_at_time">%1$s às %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,8 +70,8 @@
     <string name="change_period">Change period</string>
     <string name="grams">Grams</string>
     <string name="grams_distribution_per_hour_of_day">Grams distribution per hour of day</string>
-    <string name="current_thc_concentration">Current THC concentration: %s %%</string>
-    <string name="thc_concentration">THC Concentration(%%)</string>
+    <string name="current_thc_concentration">Current THC concentration: %s \%%</string>
+    <string name="thc_concentration">THC Concentration(%)</string>
     <string name="current_withdrawal_discomfort">Current withdrawal discomfort: %s</string>
     <string name="discomfort_strength">Discomfort strength</string>
     <string name="date_at_time">%1$s at %2$s</string>


### PR DESCRIPTION
…ings

The percentage notation was corrected in THC concentration strings across multiple language resource files. The double percentage symbols (%%) have been replaced with a single percentage symbol (%) in German, Spanish, Portuguese, and default English versions.

Closes #553