### PR TITLE
🐛 Updated default censorship settings

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/use/UseBlock.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/UseBlock.kt
@@ -152,11 +152,11 @@ private fun UseBlock(
 
 @Composable
 private fun CensureIcon(isCensored: Boolean) {
-  val chosenIcon = if (isCensored) TablerIcons.Eye else TablerIcons.EyeOff
+  val chosenIcon = if (isCensored) TablerIcons.EyeOff else TablerIcons.Eye
   Icon(chosenIcon, null, Modifier.size(18.dp))
 }
 
 @Composable
 private fun BlockText(blockText: String, isCensored: Boolean) {
-  if (isCensored) Text(blockText) else Text(stringResource(R.string.censored))
+  if (isCensored) Text(stringResource(R.string.censored)) else Text(blockText)
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/repository/BlockRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/repository/BlockRepository.kt
@@ -17,11 +17,11 @@ import kotlinx.coroutines.runBlocking
 class BlockRepository(
   private val datastore: DataStore<Preferences>
 ) {
-  val isTodayCensored = datastore.data.map { it[Today.preferencesKey] ?: true }
-  val isThisWeekCensored = datastore.data.map { it[ThisWeek.preferencesKey] ?: true }
-  val isThisMonthCensored = datastore.data.map { it[ThisMonth.preferencesKey] ?: true }
-  val isThisYearCensored = datastore.data.map { it[ThisYear.preferencesKey] ?: true }
-  val isAllTimeCensored = datastore.data.map { it[AllTime.preferencesKey] ?: true }
+  val isTodayCensored = datastore.data.map { it[Today.preferencesKey] ?: false }
+  val isThisWeekCensored = datastore.data.map { it[ThisWeek.preferencesKey] ?: false }
+  val isThisMonthCensored = datastore.data.map { it[ThisMonth.preferencesKey] ?: false }
+  val isThisYearCensored = datastore.data.map { it[ThisYear.preferencesKey] ?: false }
+  val isAllTimeCensored = datastore.data.map { it[AllTime.preferencesKey] ?: false }
 
   fun setBlockCensure(blockType: BlockType, isCensored: Boolean): Unit = runBlocking {
     datastore.edit { it[blockType.preferencesKey] = isCensored }

--- a/app/src/test/kotlin/br/com/colman/petals/use/repository/BlockRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/repository/BlockRepositoryTest.kt
@@ -12,7 +12,7 @@ class BlockRepositoryTest : FunSpec({
   val datastore: DataStore<Preferences> = PreferenceDataStoreFactory.create { tempfile(suffix = ".preferences_pb") }
   val target = BlockRepository(datastore)
 
-  test("Defaults block censor true") {
+  test("Defaults block censor to false") {
     BlockType.entries.forEach { blockType ->
       val isCensored = when (blockType) {
         BlockType.Today -> target.isTodayCensored.first()
@@ -21,17 +21,18 @@ class BlockRepositoryTest : FunSpec({
         BlockType.ThisYear -> target.isThisYearCensored.first()
         BlockType.AllTime -> target.isAllTimeCensored.first()
       }
-      isCensored shouldBe true
+      isCensored shouldBe false
     }
   }
 
   test("Changes today's block censure") {
-    target.setBlockCensure(BlockType.Today, false)
     target.isTodayCensored.first() shouldBe false
+    target.setBlockCensure(BlockType.Today, true)
+    target.isTodayCensored.first() shouldBe true
   }
 
   test("Persists specified block censure") {
-    target.setBlockCensure(BlockType.Today, false)
-    datastore.data.first()[BlockType.Today.preferencesKey] shouldBe false
+    target.setBlockCensure(BlockType.Today, true)
+    datastore.data.first()[BlockType.Today.preferencesKey] shouldBe true
   }
 })


### PR DESCRIPTION
Changed the default censorship for day, week, month, year and all time periods from true to false in the BlockRepository. Additionally updated the CensureIcon and BlockText Composables in UseBlock to correctly reflect their censorship states.

Closes #581