### PR TITLE
🐛 Add 'id' field to CSV Headers and Serializer

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/use/io/UseCsvSerializer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/UseCsvSerializer.kt
@@ -22,20 +22,22 @@ import android.content.res.Resources
 import br.com.colman.petals.R.string.amount_label
 import br.com.colman.petals.R.string.cost_per_gram_label
 import br.com.colman.petals.R.string.date_label
+import br.com.colman.petals.R.string.id_label
 import br.com.colman.petals.use.repository.UseRepository
 import com.github.doyaaaaaken.kotlincsv.dsl.csvWriter
 import kotlinx.coroutines.flow.first
 import java.io.ByteArrayOutputStream
 import kotlin.text.Charsets.UTF_8
 
-data class UseCsvHeaders(val date: String, val amount: String, val costPerGram: String) {
+data class UseCsvHeaders(val date: String, val amount: String, val costPerGram: String, val id: String) {
   constructor(resources: Resources) : this(
     resources.getString(date_label),
     resources.getString(amount_label),
-    resources.getString(cost_per_gram_label)
+    resources.getString(cost_per_gram_label),
+    resources.getString(id_label)
   )
 
-  fun toList() = listOf(date, amount, costPerGram)
+  fun toList() = listOf(date, amount, costPerGram, id)
 }
 
 class UseCsvSerializer(

--- a/app/src/main/kotlin/br/com/colman/petals/use/repository/Use.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/repository/Use.kt
@@ -23,7 +23,7 @@ data class Use(
     date.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
     amountGrams.toPlainString(),
     costPerGram.toPlainString(),
-    id // FIXME ThinkMe: should this be included?
+    id
   )
 
   override fun equals(other: Any?): Boolean {

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -166,4 +166,5 @@
     <string name="are_you_sure_delete_pause">Tem certeza que deseja remover a pausa entre %s e %s?</string>
     <string name="confirm_deletion">Confirmar Remoção</string>
     <string name="pause_time">Tempo de Pausa</string>
+    <string name="id_label">id</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@
     <string name="are_you_sure_delete_pause">Are you sure that you want to delete pause from %s to %s?</string>
     <string name="confirm_deletion">Confirm deletion</string>
     <string name="pause_time">Pause Time</string>
+    <string name="id_label">id</string>
     <plurals name="last_x_days">
         <item quantity="one">Last %s day</item>
         <item quantity="other">Last %s days</item>

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/UseCsvSerializerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/UseCsvSerializerTest.kt
@@ -37,7 +37,7 @@ import java.math.BigDecimal.ZERO
 
 class UseCsvSerializerTest : FunSpec({
   val useRepository = mockk<UseRepository>()
-  val useCsvHeaders = UseCsvHeaders("date", "amount", "cost")
+  val useCsvHeaders = UseCsvHeaders("date", "amount", "cost", "id")
   val target = UseCsvSerializer(useRepository, useCsvHeaders)
 
   context("Create CSV content") {
@@ -52,7 +52,7 @@ class UseCsvSerializerTest : FunSpec({
     }
 
     test("Includes the headers at the start of the file") {
-      file shouldStartWith "date,amount,cost\n"
+      file shouldStartWith "date,amount,cost,id\n"
     }
   }
 })


### PR DESCRIPTION
The 'id' field has been added to the UseCsvHeaders data class and the UseCsvSerializer class. This addition has also been reflected in the corresponding test file. The label for 'id' has been added to the application's string resources.

Closes #616