### PR TITLE
🚑️ Remove edge-to-edge rendering for Android 15+

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/navigation/Page.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/navigation/Page.kt
@@ -20,7 +20,10 @@ package br.com.colman.petals.navigation
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material.Icon
@@ -80,7 +83,9 @@ fun BottomNavigationBar(navController: NavHostController) {
   val navBackStackEntry by navController.currentBackStackEntryAsState()
   val currentRoute = navBackStackEntry?.destination?.route
 
-  BottomNavigation {
+  BottomNavigation(
+    Modifier.padding(bottom = WindowInsets.systemBars.asPaddingValues().calculateBottomPadding())
+  ) {
     Page.entries.forEach { page ->
       BottomNavigationItem(
         modifier = Modifier.testTag(page.name),

--- a/app/src/main/kotlin/br/com/colman/petals/navigation/TopAppBar.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/navigation/TopAppBar.kt
@@ -26,9 +26,12 @@ import androidx.compose.foundation.layout.Arrangement.SpaceBetween
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
@@ -56,7 +59,9 @@ import org.koin.compose.koinInject
 
 @Composable
 fun MyTopAppBar(navController: NavController, options: (@Composable () -> Unit)? = null) {
-  TopAppBar {
+  TopAppBar(
+    Modifier.padding(top = WindowInsets.systemBars.asPaddingValues().calculateTopPadding())
+  ) {
     Box(
       Modifier.padding(16.dp).height(56.dp).fillMaxWidth()
     ) {


### PR DESCRIPTION
By adding a top padding of the bar size and a bottom padding of the bar size, we are able to remove the forced "Edge-to-Edge" configuration from Android 15