### PR TITLE
✅ Remove @Composable from Kover reports

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -229,6 +229,19 @@ dependencies {
 
 }
 
+kover {
+  reports {
+    filters {
+      excludes {
+        annotatedBy("androidx.compose.runtime.Composable")
+        classes("*ComposableSingletons*")
+        classes("*DatabaseImpl*")
+        classes("*BuildConfig*")
+      }
+    }
+  }
+}
+
 tasks.withType<Test> {
   useJUnitPlatform()
 }


### PR DESCRIPTION
Kover doesn't support integration tests anyway, so keeping Composable (ie integration-test) functions under kover reports is not helpful.

This commit makes our test coverage reflect a value closer to reality for our unit tests