### PR TITLE
➖ Remove Glance and unused test dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -222,9 +222,6 @@ dependencies {
   // Google Reviews
   "playstoreImplementation"(libs.bundles.review)
 
-  // Glance
-  implementation(libs.bundles.glance)
-
   // Fuel
   androidTestImplementation(libs.fuel) {
     because("Specifically to make Screenshots and upload them to a localhost server")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-androidx = "1.7.0"
 compose = "1.9.0"
 datastore = "1.1.7"
 detekt = "1.23.8"
@@ -9,14 +8,11 @@ kotlin = "2.2.10"
 licensee = "1.13.0"
 vanpra-material-dialogs = "0.9.0"
 sqldelight = "2.1.0"
-glance = "1.1.1"
 mockk = "1.14.5"
 review = "2.0.2"
 
 [libraries]
 android-desugar-jdk = "com.android.tools:desugar_jdk_libs:2.1.5"
-androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx" }
-androidx-test-runner = "androidx.test:runner:1.7.0"
 apache-commons-lang = "org.apache.commons:commons-lang3:3.18.0"
 apache-commons-math = "org.apache.commons:commons-math3:3.6.1"
 compose-activity = "androidx.activity:activity-compose:1.10.1"
@@ -28,22 +24,18 @@ compose-material-tooling = { module = "androidx.compose.ui:ui-tooling", version.
 compose-navigation = "androidx.navigation:navigation-compose:2.9.3"
 compose-tabler-icons = "br.com.devsrsouza.compose.icons:tabler-icons:1.1.1"
 compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compose" }
-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "compose" }
 datastore-android = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastore" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 graph-view = "com.jjoe64:graphview:4.2.2"
-junit4 = "junit:junit:4.13.2"
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
-kotest-assertions-android = { module = "br.com.colman:kotest-assertions-android", version = "1.1.2" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
 kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.0" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
-kotest-extensions-now = { module = "io.kotest:kotest-extensions-now", version.ref = "kotest" }
 kotlin-csv = "com.jsoizo:kotlin-csv:1.10.0"
 kotlin-date-range = "me.moallemi.tools:kotlin-date-range:1.0.0"
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -61,22 +53,14 @@ sqldelight-sqlite-dialect = { module = "app.cash.sqldelight:sqlite-3-25-dialect"
 requery-sqlite = "com.github.requery:sqlite-android:3.49.0"
 play-services-ads = "com.google.android.gms:play-services-ads:24.5.0"
 play-services-billing = "com.android.billingclient:billing:8.0.0"
-glance = { module = "androidx.glance:glance", version.ref = "glance" }
-glance-widgets = { module = "androidx.glance:glance-appwidget", version.ref = "glance" }
 fuel = "com.github.kittinunf.fuel:fuel:2.3.1"
 androidx-test-core = "androidx.test:core:1.7.0"
-androidx-test-ext-junit = "androidx.test.ext:junit:1.3.0"
 review = { module = "com.google.android.play:review", version.ref = "review" }
-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "review" }
 
 [bundles]
-review = ["review", "review-ktx"]
+review = ["review"]
 androidx-test = [
-    "androidx-test-rules",
-    "androidx-test-runner",
     "androidx-test-core",
-    "androidx-test-ext-junit",
-    "junit4",
 ]
 apache-commons = [
     "apache-commons-lang",
@@ -93,7 +77,6 @@ compose = [
 ]
 compose-test = [
     "compose-ui-test",
-    "compose-ui-test-junit4",
 ]
 datastore = [
     "datastore-android",
@@ -102,7 +85,6 @@ datastore = [
 date-time = [
     "kotlin-date-range",
 ]
-glance = ["glance", "glance-widgets"]
 graph-view = [
     "graph-view",
     "mp-android-chart",
@@ -111,10 +93,11 @@ koin = [
     "koin-android",
     "koin-compose",
 ]
-kotest-jvm = ["kotest-runner-junit5", "kotest-extensions-now"]
-kotest-android = ["kotest-runner-android", "kotest-assertions-android"]
+kotest-jvm = ["kotest-runner-junit5"]
+kotest-android = ["kotest-runner-android"]
 kotest-common = ["kotest-assertions", "kotest-property", "kotest-framework-datatest"]
 mockk-android = ["mockk-android", "mockk-agent"]
+
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
Remove Glance-related dependencies and unused test libraries to streamline the codebase and reduce maintenance overhead.