### PR TITLE
⬆️ Upgrade Kotest to 6.0.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -245,6 +245,7 @@ kover {
 
 tasks.withType<Test> {
   useJUnitPlatform()
+  systemProperty("kotest.framework.config.fqn", "br.com.colman.petals.KotestConfig")
 }
 
 tasks.detekt {

--- a/app/src/test/kotlin/br/com/colman/petals/statistics/graph/formatter/DayOfWeekFormatterTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/statistics/graph/formatter/DayOfWeekFormatterTest.kt
@@ -1,40 +1,39 @@
 package br.com.colman.petals.statistics.graph.formatter
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.data.Row2
-import io.kotest.data.forAll
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import java.util.Locale
 
 class DayOfWeekFormatterTest : FunSpec({
-  test("getFormattedValue returns correctly formatted day of the week (US Locale)") {
+  context("getFormattedValue returns correctly formatted day of the week (US Locale)") {
     Locale.setDefault(Locale.US)
-    forAll(
-      Row2(1f, "Mon"),
-      Row2(2f, "Tue"),
-      Row2(3f, "Wed"),
-      Row2(4f, "Thu"),
-      Row2(5f, "Fri"),
-      Row2(6f, "Sat"),
-      Row2(7f, "Sun")
-    ) { dayAsFloat, expectedDay ->
+    withData(
+      Pair(1f, "Mon"),
+      Pair(2f, "Tue"),
+      Pair(3f, "Wed"),
+      Pair(4f, "Thu"),
+      Pair(5f, "Fri"),
+      Pair(6f, "Sat"),
+      Pair(7f, "Sun")
+    ) { (dayAsFloat, expectedDay) ->
 
       val actual = DayOfWeekFormatter.getFormattedValue(dayAsFloat, null)
       actual shouldBe expectedDay
     }
   }
 
-  test("getFormattedValue returns correctly formatted day of the week (BR Locale)") {
+  context("getFormattedValue returns correctly formatted day of the week (BR Locale)") {
     Locale.setDefault(Locale("pt", "BR"))
-    forAll(
-      Row2(1f, "seg"),
-      Row2(2f, "ter"),
-      Row2(3f, "qua"),
-      Row2(4f, "qui"),
-      Row2(5f, "sex"),
-      Row2(6f, "sáb"),
-      Row2(7f, "dom")
-    ) { dayAsFloat, expectedDay ->
+    withData(
+      Pair(1f, "seg"),
+      Pair(2f, "ter"),
+      Pair(3f, "qua"),
+      Pair(4f, "qui"),
+      Pair(5f, "sex"),
+      Pair(6f, "sáb"),
+      Pair(7f, "dom")
+    ) { (dayAsFloat, expectedDay) ->
 
       val actual = DayOfWeekFormatter.getFormattedValue(dayAsFloat, null)
       actual shouldBe expectedDay

--- a/app/src/test/kotlin/br/com/colman/petals/statistics/graph/formatter/DaysSinceFirstUseFormatterTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/statistics/graph/formatter/DaysSinceFirstUseFormatterTest.kt
@@ -2,8 +2,7 @@ package br.com.colman.petals.statistics.graph.formatter
 
 import br.com.colman.petals.use.repository.Use
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.data.Row2
-import io.kotest.data.forAll
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
 import java.time.LocalDateTime
 import java.time.Month
@@ -16,13 +15,13 @@ class DaysSinceFirstUseFormatterTest : FunSpec({
     Use(LocalDateTime.of(2021, Month.FEBRUARY, 9, 9, 30), 0.6.toBigDecimal(), 18.toBigDecimal())
   )
 
-  test("getFormattedValue returns correctly formatted days since first use (yyyy-MM-dd)") {
-    forAll(
-      Row2(0f, "2021-02-06"),
-      Row2(1f, "2021-02-07"),
-      Row2(2f, "2021-02-08"),
-      Row2(3f, "2021-02-09")
-    ) { value, expectedDay ->
+  context("getFormattedValue returns correctly formatted days since first use (yyyy-MM-dd)") {
+    withData(
+      Pair(0f, "2021-02-06"),
+      Pair(1f, "2021-02-07"),
+      Pair(2f, "2021-02-08"),
+      Pair(3f, "2021-02-09")
+    ) { (value, expectedDay) ->
       val actual = DaysSinceFirstUseFormatter(uses, "yyyy-MM-dd").formatDate.getFormattedValue(value, null)
       actual shouldBe expectedDay
     }

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/input/UseImporterTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/input/UseImporterTest.kt
@@ -52,7 +52,7 @@ class UseImporterTest : FunSpec({
 
   context("Data ingestion") {
     test("Doesn't call database when a line is wrong") {
-      val wrongLine = "invalid,csv,line"
+      val wrongLine = "invalid,csv,line,is,invalid"
 
       target.import(List(2) { wrongLine })
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ compose = "1.9.0"
 datastore = "1.1.7"
 detekt = "1.23.8"
 koin = "4.1.0"
-kotest = "5.9.1"
+kotest = "6.0.1"
 kotlin = "2.2.10"
 licensee = "1.13.0"
 vanpra-material-dialogs = "0.9.0"
@@ -95,7 +95,7 @@ koin = [
 ]
 kotest-jvm = ["kotest-runner-junit5"]
 kotest-android = ["kotest-runner-android"]
-kotest-common = ["kotest-assertions", "kotest-property", "kotest-framework-datatest"]
+kotest-common = ["kotest-assertions", "kotest-property"]
 mockk-android = ["mockk-android", "mockk-agent"]
 
 


### PR DESCRIPTION
Replace deprecated `forAll` with `withData` to align with new
testing practices. Adjust configurations and tests accordingly
for compatibility with the updated library.

Signed-off-by: Leonardo Colman Lopes <dev@leonardo.colman.com.br>