### PR TITLE
⬆️ Bump github-workflows-kt to 4.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/build-debug.main.kts
+++ b/.github/workflows/build-debug.main.kts
@@ -1,6 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v4")

--- a/.github/workflows/build-release.main.kts
+++ b/.github/workflows/build-release.main.kts
@@ -1,6 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v4")

--- a/.github/workflows/dependency-license-analysis.main.kts
+++ b/.github/workflows/dependency-license-analysis.main.kts
@@ -1,6 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v4")

--- a/.github/workflows/detekt.main.kts
+++ b/.github/workflows/detekt.main.kts
@@ -1,6 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v4")

--- a/.github/workflows/kover.main.kts
+++ b/.github/workflows/kover.main.kts
@@ -1,7 +1,8 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
 @file:CompilerOptions("-Xmulti-dollar-interpolation")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v4")

--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -1,6 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v3")
@@ -19,7 +20,7 @@ import io.github.typesafegithub.workflows.actions.softprops.ActionGhRelease
 import io.github.typesafegithub.workflows.domain.RunnerType.UbuntuLatest
 import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
 import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch.Input
-import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch.Type.String
+import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch.Input.Type.String
 import io.github.typesafegithub.workflows.dsl.expressions.Contexts
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
@@ -36,7 +37,7 @@ workflow(
         "version_type" to Input(
           description = "Type of version bump (major, minor, patch)",
           required = true,
-          type = WorkflowDispatch.Type.Choice,
+          type = WorkflowDispatch.Input.Type.Choice,
           options = listOf("major", "minor", "patch")
         ),
         "changelog" to Input(

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - id: 'step-0'
       name: 'Check out'
-      uses: 'actions/checkout@v4'
+      uses: 'actions/checkout@v3'
     - id: 'step-1'
       name: 'Execute script'
       run: 'rm ''.github/workflows/release.yaml'' && ''.github/workflows/release.main.kts'''

--- a/.github/workflows/unit-tests.main.kts
+++ b/.github/workflows/unit-tests.main.kts
@@ -1,6 +1,7 @@
 #!/usr/bin/env kotlin
 @file:Repository("https://repo1.maven.org/maven2/")
-@file:DependsOn("io.github.typesafegithub:github-workflows-kt:3.7.0")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0-SNAPSHOT")
 
 @file:Repository("https://bindings.krzeminski.it")
 @file:DependsOn("actions:checkout:v4")


### PR DESCRIPTION
Trials the upcoming **github-workflows-kt 4.0.0** (currently `4.0.0-SNAPSHOT`) across all CI workflow scripts, to give the maintainer feedback before release.

## Changes
- Point all 7 `.main.kts` scripts at `4.0.0-SNAPSHOT` and add the Sonatype `maven-snapshots` repository.
- **Breaking-change fix** in `release.main.kts`: `WorkflowDispatch` input types moved under `Input` — now `WorkflowDispatch.Input.Type.Choice` / `.String`.

## Generated YAML
All 7 scripts compile and regenerate cleanly. 6 of 7 YAML files are **byte-identical** to before (v4 output is backward-compatible). The only YAML change is `release.yaml`: the auto-generated consistency-check job's checkout now follows the declared `actions:checkout` binding (`v3`) instead of being hardcoded to `v4`.

## ⚠️ Note for reviewers
4.0.0 is built with **Kotlin 2.4.0** — the scripts must be run with Kotlin 2.4.0. Older toolchains (e.g. 2.2.x) fail with:
```
error: module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.4.0, expected version is 2.2.0.
error: unresolved reference 'workflow'.
```
The CI `check_yaml_consistency` job will need a 2.4.0 toolchain to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)