### PR TITLE
⬆️ Bump compileSdk/targetSdk to 36 and AGP to 9.2.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,14 +42,14 @@ repositories {
 
 android {
   namespace = "br.com.colman.petals"
-  compileSdk = 35
+  compileSdk = 36
 
   defaultConfig {
     applicationId = "br.com.colman.petals"
     minSdk = 26
-    targetSdk = 35
-    versionCode = 3040000
-    versionName = "3.40.0"
+    targetSdk = 36
+    versionCode = 3040001
+    versionName = "3.40.1"
 
     testApplicationId = "$applicationId.test"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ buildscript {
   dependencies {
     classpath("com.android.tools.build:gradle") {
       version {
-        strictly("8.7.3")
+        strictly("9.2.1")
       }
     }
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,10 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8 --illegal-access=permit
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+# SQLDelight only supports the legacy Variant API DSL as of 2.3.2 (upstream
+# issues sqldelight/sqldelight#5940, #6078 are unresolved). Opt out of AGP 9's
+# built-in Kotlin / new DSL until SQLDelight ships support; officially
+# supported through AGP 9.x, mandatory removal lands in AGP 10.
+android.builtInKotlin=false
+android.newDsl=false


### PR DESCRIPTION
## Summary
- `compileSdk`/`targetSdk` 35 → 36 (`app/build.gradle.kts`)
- AGP 8.7.3 → 9.2.1, the latest stable 9.x release (only stable AGP supporting compileSdk 36/36.1)
- SQLDelight 2.3.2 doesn't yet support AGP 9's built-in Kotlin / new DSL (upstream issues [sqldelight/sqldelight#5940](https://github.com/sqldelight/sqldelight/issues/5940), [#6078](https://github.com/sqldelight/sqldelight/issues/6078) — both closed via the `android.newDsl=false` workaround, no proper fix shipped yet). Set `android.builtInKotlin=false` and `android.newDsl=false` in `gradle.properties` to opt back into the legacy DSL, which stays officially supported through the AGP 9.x line (mandatory removal only in AGP 10).

## Test plan
- [x] `./gradlew clean :app:assembleDebug` — all three flavors (fdroid/github/playstore) build clean
- [x] `./gradlew :app:testPlaystoreDebugUnitTest` — passes
- [x] Verified SQLDelight-generated `Database` class still compiles into all variant classes (custom source-registration workaround in `app/build.gradle.kts` still functions under AGP 9)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)