### PR TITLE
🔧 Fix release.main.kts/release.yaml ruby-version drift

### DIFF
--- a/.github/workflows/release.main.kts
+++ b/.github/workflows/release.main.kts
@@ -92,7 +92,7 @@ workflow(
 
     run(name = "Create Playstore Bundle", command = "./gradlew clean bundlePlaystoreRelease")
 
-    uses(action = SetupRuby(rubyVersion = "3.2.3"))
+    uses(action = SetupRuby(rubyVersion = "3.4.10"))
     run(
       name = "Publish to Playstore",
       workingDirectory = "fastlane",


### PR DESCRIPTION
## Summary
- `release.main.kts` still had `rubyVersion = "3.2.3"` while the generated `release.yaml` was bumped to `3.4.10` directly by Renovate (#1087), which only touches the generated YAML, not its Kotlin DSL source.
- This drift fails the "Check YAML consistency" job on the `Release` workflow (confirmed on run [29169341279](https://github.com/LeoColman/Petals/actions/runs/29169341279), triggered while shipping the compileSdk 36 / AGP 9.2.1 patch).
- Fix: bump `release.main.kts`'s ruby version to match, so regeneration is a no-op diff.

## Test plan
- [ ] CI green (Check YAML consistency passes)