### PR TITLE
🔧 Fix R8 release build + revert orphaned 3.40.2 version bump

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,8 +48,8 @@ android {
     applicationId = "br.com.colman.petals"
     minSdk = 26
     targetSdk = 36
-    versionCode = 3040002
-    versionName = "3.40.2"
+    versionCode = 3040001
+    versionName = "3.40.1"
 
     testApplicationId = "$applicationId.test"
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/app/proguard-android-optimize.txt
+++ b/app/proguard-android-optimize.txt
@@ -8,3 +8,7 @@
 }
 -dontwarn android.media.LoudnessCodecController$OnLoudnessCodecUpdateListener
 -dontwarn android.media.LoudnessCodecController
+-dontwarn androidx.window.extensions.area.ExtensionWindowAreaPresentation
+-dontwarn androidx.window.extensions.core.util.function.Consumer
+-dontwarn androidx.window.extensions.core.util.function.Function
+-dontwarn androidx.window.extensions.core.util.function.Predicate

--- a/fastlane/metadata/android/en-US/changelogs/3040002.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3040002.txt
@@ -1,1 +1,0 @@
-Updated internal libraries and build tooling, including Android 16 (API 36) compatibility.


### PR DESCRIPTION
## Summary
- Revert "🔖 Prepare Release 3.40.2 (3040002)": that commit/tag came from a Release run whose `Create APK` step failed on R8 before publishing anything, so it never corresponded to an actual release. The `3.40.2` tag was deleted from the remote; this reverts the version bump commit so the next patch release cleanly becomes `3.40.2` again.
- Fix the actual R8 failure: `assembleGithubRelease`/`bundlePlaystoreRelease` failed with "Missing classes detected while running R8" for 4 `androidx.window.extensions.*` reflection classes (optional OEM APIs androidx.window's own consumer rules don't cover). Added the exact `-dontwarn` rules R8 generated in `missing_rules.txt`.

## Test plan
- [x] `./gradlew assembleGithubRelease` — passes locally (previously failed with R8 missing-class error)
- [x] `./gradlew bundlePlaystoreRelease` — passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)