### PR TITLE
✨ Add automatic daily export to a chosen folder (#100)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -225,6 +225,10 @@ dependencies {
   // Glance
   implementation(libs.bundles.glance)
 
+  // WorkManager (auto-export) + SAF DocumentFile helper
+  implementation(libs.androidx.work)
+  implementation(libs.androidx.documentfile)
+
   // Fuel
   androidTestImplementation(libs.fuel) {
     because("Specifically to make Screenshots and upload them to a localhost server")

--- a/app/src/androidTest/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriterTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriterTest.kt
@@ -1,0 +1,46 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.Context
+import androidx.documentfile.provider.DocumentFile
+import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.FunSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
+
+/**
+ * The test that actually matters: proves openOutputStream(uri, "wt") really
+ * truncates for a real ContentResolver against a local file:// tree (which it
+ * reliably does — unlike some cloud DocumentsProviders, which is exactly why
+ * AutoExportDocumentWriter has the verify+recreate fallback at all). The
+ * fallback path itself can only be proven against a real flaky provider like
+ * Nextcloud — see the manual end-to-end steps in the original plan.
+ */
+class AutoExportDocumentWriterTest : FunSpec({
+  val context: Context = ApplicationProvider.getApplicationContext()
+  val treeDir = tempdir()
+  val tree = DocumentFile.fromFile(treeDir)
+
+  // documentFileFromSingleUri returns null on purpose: forces every write to
+  // re-resolve via findFile-by-name on the tree, exactly like a fresh install
+  // with no cached document Uri yet.
+  val target = AutoExportDocumentWriter(context.contentResolver, { tree }, { null })
+
+  test("overwrites PetalsExport.csv in place with no trailing bytes when the new content is shorter") {
+    val longContent = "date,amount,cost_per_gram,id,description,consumption_method\n".repeat(50)
+    val shortContent = "date,amount,cost_per_gram,id,description,consumption_method\n"
+
+    target.write(tree.uri, null, longContent)
+    val secondUri = target.write(tree.uri, null, shortContent)
+
+    context.contentResolver.openInputStream(secondUri)!!.bufferedReader().use { it.readText() } shouldBe shortContent
+    treeDir.listFiles()!!.size shouldBe 1
+  }
+
+  test("still only one file after several writes of varying length") {
+    listOf("a\n", "b".repeat(200) + "\n", "c\n", "d".repeat(80) + "\n").forEach {
+      target.write(tree.uri, null, it)
+    }
+
+    treeDir.listFiles()!!.size shouldBe 1
+  }
+})

--- a/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
@@ -20,6 +20,13 @@ package br.com.colman.petals
 
 import android.app.Application
 import br.com.colman.petals.BuildConfig.DEBUG
+import br.com.colman.petals.settings.SettingsRepository
+import br.com.colman.petals.use.io.output.auto.AutoExportScheduler
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
@@ -33,6 +40,7 @@ class PetalsApplication : Application() {
     super.onCreate()
     startKoin()
     startTimber()
+    rescheduleAutoExportIfEnabled()
   }
 
   private fun startKoin() {
@@ -45,6 +53,21 @@ class PetalsApplication : Application() {
   private fun startTimber() {
     if (DEBUG) {
       Timber.plant(Timber.DebugTree())
+    }
+  }
+
+  /**
+   * Belt-and-braces for the force-stop case: WorkManager's own reboot
+   * rescheduling only fires on BOOT_COMPLETED, not on a plain force-stop.
+   * KEEP makes schedule() idempotent, and this runs off the main thread
+   * since DataStore reads are disk IO.
+   */
+  private fun rescheduleAutoExportIfEnabled(dispatcher: CoroutineDispatcher = IO) {
+    CoroutineScope(dispatcher).launch {
+      val settingsRepository = koin.get<SettingsRepository>()
+      if (settingsRepository.isAutoExportEnabled.first()) {
+        koin.get<AutoExportScheduler>().schedule()
+      }
     }
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
@@ -31,6 +31,7 @@ import org.koin.android.ext.koin.androidContext
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
 import timber.log.Timber
+import java.io.IOException
 
 lateinit var koin: Koin
   private set
@@ -63,10 +64,20 @@ class PetalsApplication : Application() {
    * since DataStore reads are disk IO.
    */
   private fun rescheduleAutoExportIfEnabled(dispatcher: CoroutineDispatcher = IO) {
+    // This is a root coroutine: nothing is above it to catch anything it throws, so an
+    // exception here would reach the default handler and take the process down AT APP
+    // START. Failing to re-schedule a background export must never do that — the next
+    // launch (or WorkManager's own reboot rescheduling) gets another go.
     CoroutineScope(dispatcher).launch {
-      val settingsRepository = koin.get<SettingsRepository>()
-      if (settingsRepository.isAutoExportEnabled.first()) {
-        koin.get<AutoExportScheduler>().schedule()
+      try {
+        val settingsRepository = koin.get<SettingsRepository>()
+        if (settingsRepository.isAutoExportEnabled.first()) {
+          koin.get<AutoExportScheduler>().schedule()
+        }
+      } catch (e: IOException) {
+        Timber.w(e, "Could not read auto-export settings to reschedule")
+      } catch (e: IllegalStateException) {
+        Timber.w(e, "Could not reschedule auto-export")
       }
     }
   }

--- a/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/PetalsApplication.kt
@@ -23,15 +23,16 @@ import br.com.colman.petals.BuildConfig.DEBUG
 import br.com.colman.petals.settings.SettingsRepository
 import br.com.colman.petals.use.io.output.auto.AutoExportScheduler
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
 import timber.log.Timber
-import java.io.IOException
 
 lateinit var koin: Koin
   private set
@@ -68,16 +69,17 @@ class PetalsApplication : Application() {
     // exception here would reach the default handler and take the process down AT APP
     // START. Failing to re-schedule a background export must never do that — the next
     // launch (or WorkManager's own reboot rescheduling) gets another go.
-    CoroutineScope(dispatcher).launch {
-      try {
-        val settingsRepository = koin.get<SettingsRepository>()
-        if (settingsRepository.isAutoExportEnabled.first()) {
-          koin.get<AutoExportScheduler>().schedule()
-        }
-      } catch (e: IOException) {
-        Timber.w(e, "Could not read auto-export settings to reschedule")
-      } catch (e: IllegalStateException) {
-        Timber.w(e, "Could not reschedule auto-export")
+    // The handler, not a list of catch clauses, is what makes that true. Koin lookups and
+    // DataStore reads can fail in ways this code has no business enumerating, and any one
+    // of them missing from the list would be a crash on launch.
+    val doNotCrashOnLaunch = CoroutineExceptionHandler { _, throwable ->
+      Timber.w(throwable, "Could not reschedule auto-export")
+    }
+
+    CoroutineScope(dispatcher + SupervisorJob() + doNotCrashOnLaunch).launch {
+      val settingsRepository = koin.get<SettingsRepository>()
+      if (settingsRepository.isAutoExportEnabled.first()) {
+        koin.get<AutoExportScheduler>().schedule()
       }
     }
   }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import br.com.colman.petals.R.string.hours_12
 import br.com.colman.petals.R.string.hours_24
@@ -58,6 +59,12 @@ class SettingsRepository(
   val isIgnoringLongestDailyDelay = datastore.data.map { it[IsIgnoringLongestDailyDelay] ?: false }
   val isDayExtended = datastore.data.map { it[IsDayExtended] ?: false }
   val appLanguages = AppLanguage.entries.map { it.languageName }
+  val autoExportTreeUri = datastore.data.map { it[AutoExportTreeUri] }
+  val autoExportDocumentUri = datastore.data.map { it[AutoExportDocumentUri] }
+  val autoExportFolderName = datastore.data.map { it[AutoExportFolderName] }
+  val autoExportLastSuccessAt = datastore.data.map { it[AutoExportLastSuccessAt] }
+  val autoExportLastError = datastore.data.map { it[AutoExportLastError] }
+  val isAutoExportEnabled = autoExportTreeUri.map { it != null }
 
   fun setCurrencyIcon(value: String): Unit = runBlocking {
     datastore.edit { it[CurrencyIcon] = value }
@@ -112,6 +119,46 @@ class SettingsRepository(
     datastore.edit { it[IsIgnoringLongestDailyDelay] = value }
   }
 
+  fun setAutoExportTreeUri(value: String?): Unit = runBlocking {
+    datastore.edit {
+      if (value == null) it.remove(AutoExportTreeUri) else it[AutoExportTreeUri] = value
+    }
+  }
+
+  fun setAutoExportDocumentUri(value: String?): Unit = runBlocking {
+    datastore.edit {
+      if (value == null) it.remove(AutoExportDocumentUri) else it[AutoExportDocumentUri] = value
+    }
+  }
+
+  fun setAutoExportFolderName(value: String?): Unit = runBlocking {
+    datastore.edit {
+      if (value == null) it.remove(AutoExportFolderName) else it[AutoExportFolderName] = value
+    }
+  }
+
+  fun setAutoExportLastSuccessAt(value: Long?): Unit = runBlocking {
+    datastore.edit {
+      if (value == null) it.remove(AutoExportLastSuccessAt) else it[AutoExportLastSuccessAt] = value
+    }
+  }
+
+  fun setAutoExportLastError(value: String?): Unit = runBlocking {
+    datastore.edit {
+      if (value == null) it.remove(AutoExportLastError) else it[AutoExportLastError] = value
+    }
+  }
+
+  fun clearAutoExport(): Unit = runBlocking {
+    datastore.edit {
+      it.remove(AutoExportTreeUri)
+      it.remove(AutoExportDocumentUri)
+      it.remove(AutoExportFolderName)
+      it.remove(AutoExportLastSuccessAt)
+      it.remove(AutoExportLastError)
+    }
+  }
+
   companion object {
     val CurrencyIcon = stringPreferencesKey("currency_icon")
     val DateFormat = stringPreferencesKey("date_format")
@@ -125,5 +172,10 @@ class SettingsRepository(
     val IsHourOfDayLineInStatsEnabled = booleanPreferencesKey("is_hour_of_day_line_in_stats_enabled")
     val IsBreakPeriodInStatsEnabled = booleanPreferencesKey("is_break_period_in_stats_enabled")
     val IsIgnoringLongestDailyDelay = booleanPreferencesKey("is_ignoring_longest_daily_delay")
+    val AutoExportTreeUri = stringPreferencesKey("auto_export_tree_uri")
+    val AutoExportDocumentUri = stringPreferencesKey("auto_export_document_uri")
+    val AutoExportFolderName = stringPreferencesKey("auto_export_folder_name")
+    val AutoExportLastSuccessAt = longPreferencesKey("auto_export_last_success_at")
+    val AutoExportLastError = stringPreferencesKey("auto_export_last_error")
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
@@ -158,6 +158,8 @@ class SettingsRepository(
       it.remove(AutoExportLastSuccessAt)
       it.remove(AutoExportLastError)
     }
+  }
+
   fun setIsToleranceModelEnabled(value: Boolean): Unit = runBlocking {
     datastore.edit { it[IsToleranceModelEnabled] = value }
   }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.core.os.LocaleListCompat
+import br.com.colman.petals.settings.view.listitem.AutoExportListItem
+import br.com.colman.petals.settings.view.listitem.AutoExportStatus
 import br.com.colman.petals.settings.view.listitem.ClockListItem
 import br.com.colman.petals.settings.view.listitem.CurrencyListItem
 import br.com.colman.petals.settings.view.listitem.DateListItem
@@ -24,9 +26,11 @@ import br.com.colman.petals.settings.view.listitem.ShareApp
 import br.com.colman.petals.settings.view.listitem.TimeListItem
 import br.com.colman.petals.statistics.view.listitem.BreakPeriodInStatsEnabledListItem
 import br.com.colman.petals.statistics.view.listitem.HourOfDayLineInStatsEnabledListItem
+import br.com.colman.petals.use.io.output.auto.AutoExportEnabler
+import org.koin.compose.koinInject
 
 @Composable
-fun SettingsView(settingsRepository: SettingsRepository) {
+fun SettingsView(settingsRepository: SettingsRepository, autoExportEnabler: AutoExportEnabler = koinInject()) {
   val currentCurrency by settingsRepository.currencyIcon.collectAsState("$")
   val currentDateFormat by settingsRepository.dateFormat.collectAsState(settingsRepository.dateFormatList[0])
   val currentTimeFormat by settingsRepository.timeFormat.collectAsState(settingsRepository.timeFormatList[0])
@@ -77,8 +81,24 @@ fun SettingsView(settingsRepository: SettingsRepository) {
       currentBreakPeriodInStatsEnabled,
       settingsRepository::setIsBreakPeriodInStatsEnabled
     )
+    AutoExportSection(settingsRepository, autoExportEnabler)
     ShareApp()
   }
+}
+
+@Composable
+private fun AutoExportSection(settingsRepository: SettingsRepository, autoExportEnabler: AutoExportEnabler) {
+  val isAutoExportEnabled by settingsRepository.isAutoExportEnabled.collectAsState(false)
+  val autoExportFolderName by settingsRepository.autoExportFolderName.collectAsState(null)
+  val autoExportLastSuccessAt by settingsRepository.autoExportLastSuccessAt.collectAsState(null)
+  val autoExportLastError by settingsRepository.autoExportLastError.collectAsState(null)
+
+  AutoExportListItem(
+    isAutoExportEnabled,
+    AutoExportStatus(autoExportFolderName, autoExportLastSuccessAt, autoExportLastError),
+    autoExportEnabler::enable,
+    autoExportEnabler::disable
+  )
 }
 
 @Composable

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
@@ -27,8 +27,8 @@ import br.com.colman.petals.settings.view.listitem.TimeListItem
 import br.com.colman.petals.statistics.view.listitem.BreakPeriodInStatsEnabledListItem
 import br.com.colman.petals.statistics.view.listitem.HourOfDayLineInStatsEnabledListItem
 import br.com.colman.petals.use.io.output.auto.AutoExportEnabler
-import org.koin.compose.koinInject
 import br.com.colman.petals.withdrawal.view.listitem.ToleranceModelEnabledListItem
+import org.koin.compose.koinInject
 
 @Composable
 fun SettingsView(settingsRepository: SettingsRepository, autoExportEnabler: AutoExportEnabler = koinInject()) {

--- a/app/src/main/kotlin/br/com/colman/petals/settings/view/dialog/SwitchListItem.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/view/dialog/SwitchListItem.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SwitchListItem(
   icon: ImageVector,
-  @StringRes textId: Int,
-  @StringRes descriptionId: Int,
+  text: String,
+  description: String,
   initialState: Boolean,
   onChangeState: (Boolean) -> Unit,
 ) {
@@ -30,10 +30,27 @@ fun SwitchListItem(
     ListItem(
       modifier = Modifier.fillMaxWidth().weight(0.7f),
       icon = { Icon(icon, null, Modifier.size(42.dp)) },
-      secondaryText = { Text(stringResource(descriptionId)) }
+      secondaryText = { Text(description) }
     ) {
-      Text(stringResource(textId))
+      Text(text)
     }
     Switch(initialState, onChangeState, modifier = Modifier.align(CenterVertically).padding(end = 8.dp))
   }
+}
+
+@Composable
+fun SwitchListItem(
+  icon: ImageVector,
+  @StringRes textId: Int,
+  @StringRes descriptionId: Int,
+  initialState: Boolean,
+  onChangeState: (Boolean) -> Unit,
+) {
+  SwitchListItem(
+    icon = icon,
+    text = stringResource(textId),
+    description = stringResource(descriptionId),
+    initialState = initialState,
+    onChangeState = onChangeState,
+  )
 }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/view/listitem/AutoExportListItem.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/view/listitem/AutoExportListItem.kt
@@ -4,10 +4,9 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.documentfile.provider.DocumentFile
 import br.com.colman.petals.R.string.auto_export
 import br.com.colman.petals.R.string.auto_export_chosen_folder
 import br.com.colman.petals.R.string.auto_export_description
@@ -19,6 +18,7 @@ import br.com.colman.petals.R.string.auto_export_secondary
 import br.com.colman.petals.settings.view.dialog.SwitchListItem
 import compose.icons.TablerIcons
 import compose.icons.tablericons.Folder
+import kotlinx.coroutines.launch
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -30,16 +30,15 @@ import java.util.Locale
 fun AutoExportListItem(
   isEnabled: Boolean,
   status: AutoExportStatus,
-  onFolderPicked: (Uri, String) -> Unit = { _, _ -> },
-  onDisable: () -> Unit = {},
+  onFolderPicked: suspend (Uri) -> Unit = {},
+  onDisable: suspend () -> Unit = {},
 ) {
-  val context = LocalContext.current
+  // Both callbacks read DataStore and query the document provider, which is disk IO.
+  // Launching them keeps that off the main thread; the enabler hops to IO itself.
+  val scope = rememberCoroutineScope()
 
   val launcher = rememberLauncherForActivityResult(OpenDocumentTree()) { treeUri ->
-    if (treeUri != null) {
-      val name = DocumentFile.fromTreeUri(context, treeUri)?.name ?: treeUri.toString()
-      onFolderPicked(treeUri, name)
-    }
+    if (treeUri != null) scope.launch { onFolderPicked(treeUri) }
   }
 
   SwitchListItem(
@@ -50,7 +49,7 @@ fun AutoExportListItem(
     // if the user backs out of the picker, nothing is persisted, the flow
     // never emits, and the switch snaps back off on its own.
     initialState = isEnabled,
-    onChangeState = { checked -> if (checked) launcher.launch(null) else onDisable() }
+    onChangeState = { checked -> if (checked) launcher.launch(null) else scope.launch { onDisable() } }
   )
 }
 

--- a/app/src/main/kotlin/br/com/colman/petals/settings/view/listitem/AutoExportListItem.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/view/listitem/AutoExportListItem.kt
@@ -1,0 +1,75 @@
+package br.com.colman.petals.settings.view.listitem
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.documentfile.provider.DocumentFile
+import br.com.colman.petals.R.string.auto_export
+import br.com.colman.petals.R.string.auto_export_chosen_folder
+import br.com.colman.petals.R.string.auto_export_description
+import br.com.colman.petals.R.string.auto_export_folder_unavailable
+import br.com.colman.petals.R.string.auto_export_last_export
+import br.com.colman.petals.R.string.auto_export_last_failed
+import br.com.colman.petals.R.string.auto_export_never_exported
+import br.com.colman.petals.R.string.auto_export_secondary
+import br.com.colman.petals.settings.view.dialog.SwitchListItem
+import compose.icons.TablerIcons
+import compose.icons.tablericons.Folder
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+
+@Preview
+@Composable
+fun AutoExportListItem(
+  isEnabled: Boolean,
+  status: AutoExportStatus,
+  onFolderPicked: (Uri, String) -> Unit = { _, _ -> },
+  onDisable: () -> Unit = {},
+) {
+  val context = LocalContext.current
+
+  val launcher = rememberLauncherForActivityResult(OpenDocumentTree()) { treeUri ->
+    if (treeUri != null) {
+      val name = DocumentFile.fromTreeUri(context, treeUri)?.name ?: treeUri.toString()
+      onFolderPicked(treeUri, name)
+    }
+  }
+
+  SwitchListItem(
+    icon = TablerIcons.Folder,
+    text = stringResource(auto_export),
+    description = secondaryText(status),
+    // Controlled by the DataStore flow (isEnabled), not local mutableStateOf:
+    // if the user backs out of the picker, nothing is persisted, the flow
+    // never emits, and the switch snaps back off on its own.
+    initialState = isEnabled,
+    onChangeState = { checked -> if (checked) launcher.launch(null) else onDisable() }
+  )
+}
+
+@Composable
+private fun secondaryText(status: AutoExportStatus): String {
+  val folderName = status.folderName ?: return stringResource(auto_export_description)
+
+  val statusText = when {
+    status.lastError == "permission" -> stringResource(auto_export_folder_unavailable)
+    status.lastError == "io" -> stringResource(auto_export_last_failed)
+    status.lastSuccessAtEpochMillis != null ->
+      stringResource(auto_export_last_export, formatTimestamp(status.lastSuccessAtEpochMillis))
+    else -> stringResource(auto_export_never_exported)
+  }
+
+  return stringResource(auto_export_secondary, stringResource(auto_export_chosen_folder, folderName), statusText)
+}
+
+private fun formatTimestamp(epochMillis: Long): String {
+  val formatter = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).withLocale(Locale.getDefault())
+  return formatter.format(Instant.ofEpochMilli(epochMillis).atZone(ZoneId.systemDefault()))
+}

--- a/app/src/main/kotlin/br/com/colman/petals/settings/view/listitem/AutoExportStatus.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/view/listitem/AutoExportStatus.kt
@@ -1,0 +1,11 @@
+package br.com.colman.petals.settings.view.listitem
+
+/**
+ * Bundles the three DataStore-derived status fields into one parameter, so
+ * [AutoExportListItem] stays under detekt's LongParameterList threshold.
+ */
+data class AutoExportStatus(
+  val folderName: String?,
+  val lastSuccessAtEpochMillis: Long?,
+  val lastError: String?,
+)

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/UseIOModules.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/UseIOModules.kt
@@ -2,5 +2,6 @@ package br.com.colman.petals.use.io
 
 import br.com.colman.petals.use.io.input.UseInputModule
 import br.com.colman.petals.use.io.output.UseOutputModule
+import br.com.colman.petals.use.io.output.auto.AutoExportModule
 
-val UseIOModules = UseInputModule + UseOutputModule
+val UseIOModules = UseInputModule + UseOutputModule + AutoExportModule

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriter.kt
@@ -1,0 +1,144 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.documentfile.provider.DocumentFile
+import timber.log.Timber
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.nio.charset.StandardCharsets.UTF_8
+
+private const val fileName = "PetalsExport.csv"
+private const val tmpFileName = "PetalsExport-tmp.csv"
+private const val mimeType = "text/csv"
+
+// createFile() is given the name WITHOUT the extension on purpose. Providers derive
+// the extension from the MIME type and append it themselves: DocumentFile's raw
+// (file://) backing appends unconditionally, so passing "PetalsExport.csv" there
+// yields "PetalsExport.csv.csv" — after which findFile("PetalsExport.csv") misses,
+// createFile refuses to clobber the existing file, and every run throws. Passing the
+// base name lands on "PetalsExport.csv" for both raw and content:// providers.
+private const val baseName = "PetalsExport"
+private const val tmpBaseName = "PetalsExport-tmp"
+
+/**
+ * Writes the auto-export CSV into a SAF-picked folder, overwriting the same
+ * fixed [fileName] every time.
+ *
+ * `openOutputStream(uri, "wt")` is only guaranteed to open for writing; the
+ * SAF contract does not guarantee the `t` (truncate) is honored by every
+ * DocumentsProvider. [write] verifies the result and, if truncation was
+ * ignored (or the provider throws [UnsupportedOperationException] outright),
+ * falls back to writing a `.tmp` sibling, deleting the stale file, then
+ * renaming — in that order, so a crash mid-recreate leaves yesterday's file
+ * intact rather than a hole.
+ */
+class AutoExportDocumentWriter(
+  private val contentResolver: ContentResolver,
+  private val documentFileFromTreeUri: (Uri) -> DocumentFile?,
+  private val documentFileFromSingleUri: (Uri) -> DocumentFile?,
+) {
+
+  constructor(context: Context) : this(
+    context.contentResolver,
+    { DocumentFile.fromTreeUri(context, it) },
+    { DocumentFile.fromSingleUri(context, it) },
+  )
+
+  /**
+   * SAF persisted-permission grants only exist for `content:` URIs obtained
+   * through `ACTION_OPEN_DOCUMENT_TREE`. A `file:` URI (used by the
+   * instrumented test against a local temp directory) never has one and
+   * never needs one — plain filesystem permissions apply instead. In
+   * production [treeUri] is always the `content://.../tree/...` URI handed
+   * back by the picker, so this early-return branch never triggers there.
+   */
+  fun hasWritePermission(treeUri: Uri): Boolean {
+    if (treeUri.scheme == "file") return true
+    return contentResolver.persistedUriPermissions.any { it.uri == treeUri && it.isWritePermission }
+  }
+
+  fun write(treeUri: Uri, cachedDocumentUri: Uri?, content: String): Uri {
+    if (!hasWritePermission(treeUri)) throw SecurityException("Lost write permission for $treeUri")
+
+    val bytes = content.toByteArray(UTF_8)
+    val targetDocument = resolveTargetDocument(treeUri, cachedDocumentUri)
+
+    return if (tryWriteWithTruncate(targetDocument, bytes)) {
+      targetDocument.uri
+    } else {
+      recreate(treeUri, targetDocument, bytes)
+    }
+  }
+
+  private fun resolveTargetDocument(treeUri: Uri, cachedDocumentUri: Uri?): DocumentFile {
+    val cached = cachedDocumentUri?.let(documentFileFromSingleUri)
+    if (cached != null && cached.exists() && cached.canWrite()) return cached
+
+    val tree = documentFileFromTreeUri(treeUri) ?: throw FileNotFoundException("Tree not found: $treeUri")
+
+    return tree.findExisting(fileName, baseName)
+      ?: tree.createFile(mimeType, baseName)
+      ?: throw IOException("Could not create $fileName in $treeUri")
+  }
+
+  /**
+   * A provider that appends the extension lands on [withExtension]; one that takes the
+   * display name verbatim lands on [base]. Look for both, so a run never fails to find
+   * the file it wrote last time and create a duplicate beside it.
+   */
+  private fun DocumentFile.findExisting(withExtension: String, base: String) =
+    findFile(withExtension) ?: findFile(base)
+
+  private fun tryWriteWithTruncate(document: DocumentFile, bytes: ByteArray): Boolean {
+    return try {
+      writeBytes(document.uri, bytes)
+      !wasTruncationIgnored(document, bytes.size)
+    } catch (e: UnsupportedOperationException) {
+      Timber.w(e, "Provider does not honor \"wt\" truncate for ${document.uri}")
+      false
+    }
+  }
+
+  private fun wasTruncationIgnored(document: DocumentFile, expectedSize: Int): Boolean {
+    // Some providers report 0 or -1 (unknown) for length() right after a write.
+    // Only a length strictly greater than what we wrote proves leftover bytes.
+    val actual = document.length()
+    return actual > expectedSize
+  }
+
+  private fun writeBytes(uri: Uri, bytes: ByteArray) {
+    val stream = contentResolver.openOutputStream(uri, "wt")
+      ?: throw IOException("openOutputStream returned null for $uri")
+    stream.use { it.write(bytes) }
+  }
+
+  private fun recreate(treeUri: Uri, staleDocument: DocumentFile, bytes: ByteArray): Uri {
+    val tmpDocument = resolveTmpDocument(treeUri)
+
+    writeBytes(tmpDocument.uri, bytes)
+    staleDocument.delete()
+
+    return renameTmpToFinal(tmpDocument.uri)
+  }
+
+  private fun resolveTmpDocument(treeUri: Uri): DocumentFile {
+    val tree = documentFileFromTreeUri(treeUri) ?: throw FileNotFoundException("Tree not found: $treeUri")
+
+    tree.findExisting(tmpFileName, tmpBaseName)?.delete()
+    return tree.createFile(mimeType, tmpBaseName)
+      ?: throw IOException("Could not create $tmpFileName in $treeUri")
+  }
+
+  private fun renameTmpToFinal(tmpUri: Uri): Uri {
+    return try {
+      DocumentsContract.renameDocument(contentResolver, tmpUri, fileName)
+        ?: throw IOException("renameDocument returned null for $tmpUri")
+    } catch (e: UnsupportedOperationException) {
+      Timber.w(e, "Provider does not support renameDocument for $tmpUri")
+      throw IOException("Rename not supported by provider", e)
+    }
+  }
+}

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriter.kt
@@ -32,8 +32,15 @@ private const val tmpBaseName = "PetalsExport-tmp"
  * DocumentsProvider. [write] verifies the result and, if truncation was
  * ignored (or the provider throws [UnsupportedOperationException] outright),
  * falls back to writing a `.tmp` sibling, deleting the stale file, then
- * renaming — in that order, so a crash mid-recreate leaves yesterday's file
- * intact rather than a hole.
+ * renaming.
+ *
+ * That order is deliberate but it is NOT crash-atomic: a crash between the
+ * delete and the rename leaves only the tmp file, and no PetalsExport.csv at
+ * all until the next run recreates it. What the order does buy is that the
+ * export is never left truncated or half-written in place — the stale file is
+ * only removed once the replacement is durably on disk. Losing the file for a
+ * day is acceptable because it is derived data: the SQLDelight database is the
+ * source of truth and the next run rebuilds it from scratch.
  */
 class AutoExportDocumentWriter(
   private val contentResolver: ContentResolver,
@@ -119,7 +126,13 @@ class AutoExportDocumentWriter(
     val tmpDocument = resolveTmpDocument(treeUri)
 
     writeBytes(tmpDocument.uri, bytes)
-    staleDocument.delete()
+
+    // Fail here rather than at the rename: if the provider refuses to delete, the
+    // rename below collides with a name that still exists, and the error the user
+    // is shown would point at the rename instead of the actual cause.
+    if (!staleDocument.delete()) {
+      throw IOException("Could not delete stale ${staleDocument.uri} to replace it with $fileName")
+    }
 
     return renameTmpToFinal(tmpDocument.uri)
   }
@@ -127,9 +140,20 @@ class AutoExportDocumentWriter(
   private fun resolveTmpDocument(treeUri: Uri): DocumentFile {
     val tree = documentFileFromTreeUri(treeUri) ?: throw FileNotFoundException("Tree not found: $treeUri")
 
-    tree.findExisting(tmpFileName, tmpBaseName)?.delete()
+    deleteLeftoverTmp(tree)
+
     return tree.createFile(mimeType, tmpBaseName)
       ?: throw IOException("Could not create $tmpFileName in $treeUri")
+  }
+
+  /**
+   * A tmp file left behind by an earlier crash. If it cannot be removed, [DocumentFile.createFile]
+   * either returns null or silently makes a duplicate, depending on the provider — so fail loudly
+   * here instead of guessing which of those happened later.
+   */
+  private fun deleteLeftoverTmp(tree: DocumentFile) {
+    val leftoverTmp = tree.findExisting(tmpFileName, tmpBaseName) ?: return
+    if (!leftoverTmp.delete()) throw IOException("Could not delete leftover ${leftoverTmp.uri}")
   }
 
   private fun renameTmpToFinal(tmpUri: Uri): Uri {

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnabler.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnabler.kt
@@ -1,0 +1,52 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.ContentResolver
+import android.content.Intent
+import android.net.Uri
+import br.com.colman.petals.settings.SettingsRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import timber.log.Timber
+
+class AutoExportEnabler(
+  private val contentResolver: ContentResolver,
+  private val settingsRepository: SettingsRepository,
+  private val scheduler: AutoExportScheduler,
+  private val uriParser: (String) -> Uri = Uri::parse,
+) {
+
+  fun enable(treeUri: Uri, folderName: String) {
+    releasePreviousGrant()
+
+    contentResolver.takePersistableUriPermission(
+      treeUri,
+      Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+    )
+
+    settingsRepository.setAutoExportTreeUri(treeUri.toString())
+    settingsRepository.setAutoExportFolderName(folderName)
+    settingsRepository.setAutoExportLastError(null)
+
+    scheduler.schedule()
+    scheduler.exportNow()
+  }
+
+  fun disable() {
+    releasePreviousGrant()
+    settingsRepository.clearAutoExport()
+    scheduler.cancel()
+  }
+
+  private fun releasePreviousGrant() {
+    val previousUriString = runBlocking { settingsRepository.autoExportTreeUri.first() } ?: return
+
+    try {
+      contentResolver.releasePersistableUriPermission(
+        uriParser(previousUriString),
+        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+      )
+    } catch (e: SecurityException) {
+      Timber.w(e, "Could not release previous auto-export grant, permission likely already gone")
+    }
+  }
+}

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnabler.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnabler.kt
@@ -1,50 +1,70 @@
 package br.com.colman.petals.use.io.output.auto
 
 import android.content.ContentResolver
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
 import br.com.colman.petals.settings.SettingsRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+private const val readWriteFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+
+/**
+ * [enable] and [disable] are suspend and hop to [dispatcher] because everything they
+ * touch is disk IO: reading the previous tree Uri out of DataStore, querying the
+ * provider for the folder's display name, and SettingsRepository's blocking setters.
+ * They are driven straight from a Compose switch, so doing any of that on the main
+ * thread janks the UI and can ANR on a slow device.
+ */
 class AutoExportEnabler(
   private val contentResolver: ContentResolver,
   private val settingsRepository: SettingsRepository,
   private val scheduler: AutoExportScheduler,
+  private val folderNameResolver: (Uri) -> String?,
   private val uriParser: (String) -> Uri = Uri::parse,
+  private val dispatcher: CoroutineDispatcher = IO,
 ) {
 
-  fun enable(treeUri: Uri, folderName: String) {
+  constructor(
+    context: Context,
+    settingsRepository: SettingsRepository,
+    scheduler: AutoExportScheduler,
+  ) : this(
+    context.contentResolver,
+    settingsRepository,
+    scheduler,
+    { DocumentFile.fromTreeUri(context, it)?.name },
+  )
+
+  suspend fun enable(treeUri: Uri): Unit = withContext(dispatcher) {
     releasePreviousGrant()
 
-    contentResolver.takePersistableUriPermission(
-      treeUri,
-      Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
-    )
+    contentResolver.takePersistableUriPermission(treeUri, readWriteFlags)
 
     settingsRepository.setAutoExportTreeUri(treeUri.toString())
-    settingsRepository.setAutoExportFolderName(folderName)
+    settingsRepository.setAutoExportFolderName(folderNameResolver(treeUri) ?: treeUri.toString())
     settingsRepository.setAutoExportLastError(null)
 
     scheduler.schedule()
     scheduler.exportNow()
   }
 
-  fun disable() {
+  suspend fun disable(): Unit = withContext(dispatcher) {
     releasePreviousGrant()
     settingsRepository.clearAutoExport()
     scheduler.cancel()
   }
 
-  private fun releasePreviousGrant() {
-    val previousUriString = runBlocking { settingsRepository.autoExportTreeUri.first() } ?: return
+  private suspend fun releasePreviousGrant() {
+    val previousUriString = settingsRepository.autoExportTreeUri.first() ?: return
 
     try {
-      contentResolver.releasePersistableUriPermission(
-        uriParser(previousUriString),
-        Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
-      )
+      contentResolver.releasePersistableUriPermission(uriParser(previousUriString), readWriteFlags)
     } catch (e: SecurityException) {
       Timber.w(e, "Could not release previous auto-export grant, permission likely already gone")
     }

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportModule.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportModule.kt
@@ -1,0 +1,14 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.Context
+import androidx.work.WorkManager
+import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.module
+
+val AutoExportModule = module {
+  single { WorkManager.getInstance(get<Context>()) }
+  single { AutoExportDocumentWriter(get()) }
+  singleOf(::AutoExportScheduler)
+  single { AutoExporter(get(), get(), get()) }
+  single { AutoExportEnabler(get(), get(), get()) }
+}

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportModule.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportModule.kt
@@ -10,5 +10,5 @@ val AutoExportModule = module {
   single { AutoExportDocumentWriter(get()) }
   singleOf(::AutoExportScheduler)
   single { AutoExporter(get(), get(), get()) }
-  single { AutoExportEnabler(get(), get(), get()) }
+  single { AutoExportEnabler(get<Context>(), get(), get()) }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportScheduler.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportScheduler.kt
@@ -1,0 +1,41 @@
+package br.com.colman.petals.use.io.output.auto
+
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy.KEEP
+import androidx.work.ExistingWorkPolicy.REPLACE
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit.DAYS
+
+private const val periodicWorkName = "petals-auto-export-daily"
+private const val oneTimeWorkName = "petals-auto-export-now"
+
+class AutoExportScheduler(
+  private val workManager: WorkManager,
+) {
+
+  fun schedule() {
+    val request = PeriodicWorkRequestBuilder<AutoExportWorker>(1, DAYS)
+      // Constraints.NONE is required here, not optional: the fdroid flavor's
+      // merged manifest has no ACCESS_NETWORK_STATE (removed via
+      // tools:node="remove" in app/src/main/AndroidManifest.xml; only the
+      // playstore flavor's ads SDK adds it back). Calling
+      // setRequiredNetworkType(...) would throw SecurityException at runtime
+      // on fdroid only, past every CI check. Do not add a network constraint.
+      .setConstraints(Constraints.NONE)
+      .build()
+
+    workManager.enqueueUniquePeriodicWork(periodicWorkName, KEEP, request)
+  }
+
+  fun exportNow() {
+    val request = OneTimeWorkRequestBuilder<AutoExportWorker>().build()
+    workManager.enqueueUniqueWork(oneTimeWorkName, REPLACE, request)
+  }
+
+  fun cancel() {
+    workManager.cancelUniqueWork(periodicWorkName)
+    workManager.cancelUniqueWork(oneTimeWorkName)
+  }
+}

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportScheduler.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportScheduler.kt
@@ -24,6 +24,12 @@ class AutoExportScheduler(
       // setRequiredNetworkType(...) would throw SecurityException at runtime
       // on fdroid only, past every CI check. Do not add a network constraint.
       .setConstraints(Constraints.NONE)
+      // WorkManager runs a periodic request's FIRST iteration immediately. Without this
+      // delay it races the exportNow() one-shot that enable() fires alongside it: both
+      // workers start within milliseconds, neither sees a file yet, both call
+      // createFile(), and the provider dedupes the loser into "PetalsExport (1).csv".
+      // The immediate export is exportNow()'s job; the periodic one starts a day later.
+      .setInitialDelay(1, DAYS)
       .build()
 
     workManager.enqueueUniquePeriodicWork(periodicWorkName, KEEP, request)

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportWorker.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportWorker.kt
@@ -6,7 +6,9 @@ import androidx.work.WorkerParameters
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
-private const val maxAttempts = 3
+// runAttemptCount is 0 on the first run, so this is the number of RETRIES after that
+// first attempt: retry while 0..1, give up on the third run. Three attempts in total.
+private const val maxRetries = 2
 
 /**
  * Thin CoroutineWorker: WorkManager's default WorkerFactory reflects the
@@ -26,7 +28,7 @@ class AutoExportWorker(
     return when (autoExporter.export()) {
       AutoExportResult.Success -> Result.success()
       AutoExportResult.PermissionLost -> Result.failure()
-      AutoExportResult.Transient -> if (runAttemptCount < maxAttempts) Result.retry() else Result.failure()
+      AutoExportResult.Transient -> if (runAttemptCount < maxRetries) Result.retry() else Result.failure()
     }
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportWorker.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportWorker.kt
@@ -1,0 +1,32 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+private const val maxAttempts = 3
+
+/**
+ * Thin CoroutineWorker: WorkManager's default WorkerFactory reflects the
+ * (Context, WorkerParameters) constructor, so no custom WorkerFactory or
+ * Configuration.Provider is needed. Koin starts in PetalsApplication.onCreate,
+ * always before any worker can run in this process (the Glance widget already
+ * relies on the same ordering).
+ */
+class AutoExportWorker(
+  context: Context,
+  workerParameters: WorkerParameters,
+) : CoroutineWorker(context, workerParameters), KoinComponent {
+
+  private val autoExporter: AutoExporter by inject()
+
+  override suspend fun doWork(): Result {
+    return when (autoExporter.export()) {
+      AutoExportResult.Success -> Result.success()
+      AutoExportResult.PermissionLost -> Result.failure()
+      AutoExportResult.Transient -> if (runAttemptCount < maxAttempts) Result.retry() else Result.failure()
+    }
+  }
+}

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExporter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExporter.kt
@@ -1,0 +1,57 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.net.Uri
+import br.com.colman.petals.settings.SettingsRepository
+import br.com.colman.petals.use.io.output.UseCsvSerializer
+import kotlinx.coroutines.flow.first
+import timber.log.Timber
+import java.io.FileNotFoundException
+import java.io.IOException
+import java.time.Instant
+
+sealed interface AutoExportResult {
+  data object Success : AutoExportResult
+  data object PermissionLost : AutoExportResult
+  data object Transient : AutoExportResult
+}
+
+class AutoExporter(
+  private val settingsRepository: SettingsRepository,
+  private val useCsvSerializer: UseCsvSerializer,
+  private val documentWriter: AutoExportDocumentWriter,
+  private val uriParser: (String) -> Uri = Uri::parse,
+) {
+
+  suspend fun export(): AutoExportResult {
+    val treeUriString = settingsRepository.autoExportTreeUri.first() ?: return AutoExportResult.Success
+
+    return try {
+      writeExport(treeUriString)
+      AutoExportResult.Success
+    } catch (e: SecurityException) {
+      Timber.w(e, "Lost permission to auto-export folder")
+      settingsRepository.setAutoExportLastError("permission")
+      AutoExportResult.PermissionLost
+    } catch (e: FileNotFoundException) {
+      Timber.w(e, "Auto-export folder no longer exists")
+      settingsRepository.setAutoExportLastError("permission")
+      AutoExportResult.PermissionLost
+    } catch (e: IOException) {
+      Timber.w(e, "Transient error during auto-export")
+      settingsRepository.setAutoExportLastError("io")
+      AutoExportResult.Transient
+    }
+  }
+
+  private suspend fun writeExport(treeUriString: String) {
+    val treeUri = uriParser(treeUriString)
+    val cachedDocumentUri = settingsRepository.autoExportDocumentUri.first()?.let(uriParser)
+
+    val content = useCsvSerializer.computeUseCsv()
+    val writtenUri = documentWriter.write(treeUri, cachedDocumentUri, content)
+
+    settingsRepository.setAutoExportDocumentUri(writtenUri.toString())
+    settingsRepository.setAutoExportLastSuccessAt(Instant.now().toEpochMilli())
+    settingsRepository.setAutoExportLastError(null)
+  }
+}

--- a/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExporter.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/io/output/auto/AutoExporter.kt
@@ -4,6 +4,8 @@ import android.net.Uri
 import br.com.colman.petals.settings.SettingsRepository
 import br.com.colman.petals.use.io.output.UseCsvSerializer
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -22,7 +24,15 @@ class AutoExporter(
   private val uriParser: (String) -> Uri = Uri::parse,
 ) {
 
-  suspend fun export(): AutoExportResult {
+  /**
+   * Two exports must never run at once. Both would resolve the target document before
+   * either had created it, both would call createFile(), and the provider would dedupe
+   * the loser into "PetalsExport (1).csv" — leaving a stray duplicate forever. This is
+   * a Koin single, so one lock covers every caller in the process.
+   */
+  private val exportLock = Mutex()
+
+  suspend fun export(): AutoExportResult = exportLock.withLock {
     val treeUriString = settingsRepository.autoExportTreeUri.first() ?: return AutoExportResult.Success
 
     return try {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="auto_export_never_exported">Not exported yet</string>
     <string name="auto_export_last_export">Last export: %s</string>
     <string name="auto_export_last_failed">Last export failed. It will be retried.</string>
-    <string name="auto_export_folder_unavailable">Folder unavailable. Tap to choose it again.</string>
+    <string name="auto_export_folder_unavailable">Folder unavailable. Toggle off and on to choose it again.</string>
     <string name="end_date">End Date</string>
     <string name="start_date">Start Date</string>
     <string name="change_period">Change period</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,6 +66,14 @@
     <!-- Java uses `import` as a reserved keyword. Can't be used -->
     <string name="export_export">Export</string>
     <!-- We should match import_import, so it's cute. -->
+    <string name="auto_export">Automatic daily export</string>
+    <string name="auto_export_description">Automatically back up your uses to a folder you choose, once a day. Works with cloud-synced folders too.</string>
+    <string name="auto_export_secondary">%1$s — %2$s</string>
+    <string name="auto_export_chosen_folder">Folder: %s</string>
+    <string name="auto_export_never_exported">Not exported yet</string>
+    <string name="auto_export_last_export">Last export: %s</string>
+    <string name="auto_export_last_failed">Last export failed. It will be retried.</string>
+    <string name="auto_export_folder_unavailable">Folder unavailable. Tap to choose it again.</string>
     <string name="end_date">End Date</string>
     <string name="start_date">Start Date</string>
     <string name="change_period">Change period</string>

--- a/app/src/test/kotlin/br/com/colman/petals/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/settings/SettingsRepositoryTest.kt
@@ -1,6 +1,11 @@
 package br.com.colman.petals.settings
 
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import br.com.colman.petals.settings.SettingsRepository.Companion.AutoExportDocumentUri
+import br.com.colman.petals.settings.SettingsRepository.Companion.AutoExportFolderName
+import br.com.colman.petals.settings.SettingsRepository.Companion.AutoExportLastError
+import br.com.colman.petals.settings.SettingsRepository.Companion.AutoExportLastSuccessAt
+import br.com.colman.petals.settings.SettingsRepository.Companion.AutoExportTreeUri
 import br.com.colman.petals.settings.SettingsRepository.Companion.CurrencyIcon
 import br.com.colman.petals.settings.SettingsRepository.Companion.DateFormat
 import br.com.colman.petals.settings.SettingsRepository.Companion.DecimalPrecision
@@ -203,5 +208,65 @@ class SettingsRepositoryTest : FunSpec({
   test("Persists extended day setting to storage") {
     target.setDayExtended(true)
     datastore.data.first()[IsDayExtended] shouldBe true
+  }
+
+  test("Auto export tree uri defaults to null") {
+    target.autoExportTreeUri.first() shouldBe null
+  }
+
+  test("isAutoExportEnabled is false by default") {
+    target.isAutoExportEnabled.first() shouldBe false
+  }
+
+  test("Setting auto export tree uri enables auto export") {
+    target.setAutoExportTreeUri("content://tree")
+    target.autoExportTreeUri.first() shouldBe "content://tree"
+    target.isAutoExportEnabled.first() shouldBe true
+  }
+
+  test("Persists auto export tree uri to storage") {
+    target.setAutoExportTreeUri("content://tree")
+    datastore.data.first()[AutoExportTreeUri] shouldBe "content://tree"
+  }
+
+  test("Setting auto export document uri persists it") {
+    target.setAutoExportDocumentUri("content://tree/doc")
+    target.autoExportDocumentUri.first() shouldBe "content://tree/doc"
+    datastore.data.first()[AutoExportDocumentUri] shouldBe "content://tree/doc"
+  }
+
+  test("Setting auto export folder name persists it") {
+    target.setAutoExportFolderName("My Folder")
+    target.autoExportFolderName.first() shouldBe "My Folder"
+    datastore.data.first()[AutoExportFolderName] shouldBe "My Folder"
+  }
+
+  test("Setting auto export last success timestamp persists it") {
+    target.setAutoExportLastSuccessAt(123L)
+    target.autoExportLastSuccessAt.first() shouldBe 123L
+    datastore.data.first()[AutoExportLastSuccessAt] shouldBe 123L
+  }
+
+  test("Setting auto export last error persists it") {
+    target.setAutoExportLastError("io")
+    target.autoExportLastError.first() shouldBe "io"
+    datastore.data.first()[AutoExportLastError] shouldBe "io"
+  }
+
+  test("Clearing auto export removes all related keys") {
+    target.setAutoExportTreeUri("content://tree")
+    target.setAutoExportDocumentUri("content://tree/doc")
+    target.setAutoExportFolderName("My Folder")
+    target.setAutoExportLastSuccessAt(123L)
+    target.setAutoExportLastError("io")
+
+    target.clearAutoExport()
+
+    target.autoExportTreeUri.first() shouldBe null
+    target.autoExportDocumentUri.first() shouldBe null
+    target.autoExportFolderName.first() shouldBe null
+    target.autoExportLastSuccessAt.first() shouldBe null
+    target.autoExportLastError.first() shouldBe null
+    target.isAutoExportEnabled.first() shouldBe false
   }
 })

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/UseIOModulesTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/UseIOModulesTest.kt
@@ -2,12 +2,13 @@ package br.com.colman.petals.use.io
 
 import br.com.colman.petals.use.io.input.UseInputModule
 import br.com.colman.petals.use.io.output.UseOutputModule
+import br.com.colman.petals.use.io.output.auto.AutoExportModule
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class UseIOModulesTest : FunSpec({
 
-  test("UseIOModules should be a list of just the InputModule and the OutputModule") {
-    UseIOModules shouldBe listOf(UseInputModule, UseOutputModule)
+  test("UseIOModules should be a list of just the InputModule, OutputModule and AutoExportModule") {
+    UseIOModules shouldBe listOf(UseInputModule, UseOutputModule, AutoExportModule)
   }
 })

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriterTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriterTest.kt
@@ -169,6 +169,7 @@ class AutoExportDocumentWriterTest : FunSpec({
       val staleDocument = mockk<DocumentFile>(relaxed = true) {
         every { uri } returns staleUri
         every { length() } returns 999L // longer than what we're about to write: truncate ignored
+        every { delete() } returns true
       }
       val tmpUri = mockk<Uri>()
       val tmpDocument = mockk<DocumentFile>(relaxed = true) { every { uri } returns tmpUri }
@@ -197,6 +198,64 @@ class AutoExportDocumentWriterTest : FunSpec({
     } finally {
       unmockkStatic(DocumentsContract::class)
     }
+  }
+
+  // Without this, the rename below collides with a name that still exists and the user
+  // is shown an error about the rename rather than the delete that actually failed.
+  test("throws IOException when the provider refuses to delete the stale file") {
+    mockkStatic(DocumentsContract::class)
+    try {
+      val tree = treeUri()
+      val contentResolver = mockk<ContentResolver> {
+        every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+      }
+
+      val staleUri = mockk<Uri>()
+      val staleDocument = mockk<DocumentFile>(relaxed = true) {
+        every { uri } returns staleUri
+        every { length() } returns 999L
+        every { delete() } returns false
+      }
+      val tmpDocument = mockk<DocumentFile>(relaxed = true) { every { uri } returns mockk() }
+
+      val treeDocument = mockk<DocumentFile> {
+        every { findFile(fileName) } returns staleDocument
+        every { findFile(tmpFileName) } returns null
+        every { findFile(tmpBaseName) } returns null
+        every { createFile("text/csv", tmpBaseName) } returns tmpDocument
+      }
+      every { contentResolver.openOutputStream(any(), "wt") } returns ByteArrayOutputStream()
+
+      val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+      shouldThrow<IOException> { target.write(tree, null, "content") }
+    } finally {
+      unmockkStatic(DocumentsContract::class)
+    }
+  }
+
+  test("throws IOException when a leftover tmp file cannot be deleted") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+
+    val staleUri = mockk<Uri>()
+    val staleDocument = mockk<DocumentFile>(relaxed = true) {
+      every { uri } returns staleUri
+      every { length() } returns 999L
+    }
+    val leftoverTmp = mockk<DocumentFile>(relaxed = true) { every { delete() } returns false }
+
+    val treeDocument = mockk<DocumentFile> {
+      every { findFile(fileName) } returns staleDocument
+      every { findFile(tmpFileName) } returns leftoverTmp
+    }
+    every { contentResolver.openOutputStream(staleUri, "wt") } returns ByteArrayOutputStream()
+
+    val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+    shouldThrow<IOException> { target.write(tree, null, "content") }
   }
 
   test("does not recreate when length() reports the provider sentinel values 0 or -1") {

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriterTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportDocumentWriterTest.kt
@@ -1,0 +1,222 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.ContentResolver
+import android.content.UriPermission
+import android.net.Uri
+import android.provider.DocumentsContract
+import androidx.documentfile.provider.DocumentFile
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verifyOrder
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+
+private const val fileName = "PetalsExport.csv"
+private const val tmpFileName = "PetalsExport-tmp.csv"
+private const val baseName = "PetalsExport"
+private const val tmpBaseName = "PetalsExport-tmp"
+
+class AutoExportDocumentWriterTest : FunSpec({
+
+  fun treeUri() = mockk<Uri>(relaxed = true) { every { scheme } returns "content" }
+
+  fun grantedPermission(uri: Uri) = mockk<UriPermission> {
+    every { this@mockk.uri } returns uri
+    every { isWritePermission } returns true
+  }
+
+  test("throws SecurityException when write permission is missing") {
+    val contentResolver = mockk<ContentResolver> { every { persistedUriPermissions } returns emptyList() }
+    val target = AutoExportDocumentWriter(contentResolver, { mockk() }, { mockk() })
+
+    shouldThrow<SecurityException> { target.write(treeUri(), null, "content") }
+  }
+
+  test("uses the cached document Uri when it still exists and is writable") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+    val cachedUri = mockk<Uri>()
+    val cachedDocument = mockk<DocumentFile> {
+      every { exists() } returns true
+      every { canWrite() } returns true
+      every { uri } returns cachedUri
+      every { length() } returns 7L
+    }
+    every { contentResolver.openOutputStream(cachedUri, "wt") } returns ByteArrayOutputStream()
+
+    val target = AutoExportDocumentWriter(contentResolver, { mockk() }, { cachedDocument })
+
+    target.write(tree, cachedUri, "content") shouldBe cachedUri
+  }
+
+  test("falls back to findFile then createFile when the cached Uri is not usable") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+
+    val existingUri = mockk<Uri>()
+    val existingDocument = mockk<DocumentFile> {
+      every { uri } returns existingUri
+      every { length() } returns 7L
+    }
+    val treeDocument = mockk<DocumentFile> { every { findFile(fileName) } returns existingDocument }
+    every { contentResolver.openOutputStream(existingUri, "wt") } returns ByteArrayOutputStream()
+
+    val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+    target.write(tree, null, "content") shouldBe existingUri
+  }
+
+  test("creates a new file when none exists, and throws IOException if createFile returns null") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+
+    val treeDocumentNoCreate = mockk<DocumentFile> {
+      every { findFile(fileName) } returns null
+      every { findFile(baseName) } returns null
+      every { createFile("text/csv", baseName) } returns null
+    }
+    val target = AutoExportDocumentWriter(contentResolver, { treeDocumentNoCreate }, { null })
+
+    shouldThrow<IOException> { target.write(tree, null, "content") }
+  }
+
+  // Regression: passing the name WITH the extension makes providers that append the
+  // extension themselves produce "PetalsExport.csv.csv", after which findFile misses,
+  // createFile refuses to overwrite, and every subsequent export throws.
+  test("creates the file with the base name, letting the provider append the extension") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+
+    val createdUri = mockk<Uri>()
+    val createdDocument = mockk<DocumentFile> {
+      every { uri } returns createdUri
+      every { length() } returns 7L
+    }
+    val treeDocument = mockk<DocumentFile> {
+      every { findFile(fileName) } returns null
+      every { findFile(baseName) } returns null
+      every { createFile("text/csv", baseName) } returns createdDocument
+    }
+    every { contentResolver.openOutputStream(createdUri, "wt") } returns ByteArrayOutputStream()
+
+    val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+    target.write(tree, null, "content") shouldBe createdUri
+  }
+
+  // A provider that took the display name verbatim leaves a file with no extension.
+  // Finding it is what stops the next run from creating a duplicate beside it.
+  test("finds an existing file stored under the base name, without an extension") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+
+    val existingUri = mockk<Uri>()
+    val existingDocument = mockk<DocumentFile> {
+      every { uri } returns existingUri
+      every { length() } returns 7L
+    }
+    val treeDocument = mockk<DocumentFile> {
+      every { findFile(fileName) } returns null
+      every { findFile(baseName) } returns existingDocument
+    }
+    every { contentResolver.openOutputStream(existingUri, "wt") } returns ByteArrayOutputStream()
+
+    val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+    target.write(tree, null, "content") shouldBe existingUri
+  }
+
+  test("throws IOException when openOutputStream returns null") {
+    val tree = treeUri()
+    val contentResolver = mockk<ContentResolver> {
+      every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+    }
+
+    val documentUri = mockk<Uri>()
+    val document = mockk<DocumentFile> { every { uri } returns documentUri }
+    val treeDocument = mockk<DocumentFile> { every { findFile(fileName) } returns document }
+    every { contentResolver.openOutputStream(documentUri, "wt") } returns null
+
+    val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+    shouldThrow<IOException> { target.write(tree, null, "content") }
+  }
+
+  test("recreates via a tmp file when truncate is ignored, writing the tmp file before deleting the stale one") {
+    mockkStatic(DocumentsContract::class)
+    try {
+      val tree = treeUri()
+      val contentResolver = mockk<ContentResolver> {
+        every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+      }
+
+      val staleUri = mockk<Uri>()
+      val staleDocument = mockk<DocumentFile>(relaxed = true) {
+        every { uri } returns staleUri
+        every { length() } returns 999L // longer than what we're about to write: truncate ignored
+      }
+      val tmpUri = mockk<Uri>()
+      val tmpDocument = mockk<DocumentFile>(relaxed = true) { every { uri } returns tmpUri }
+      val renamedUri = mockk<Uri>()
+
+      val treeDocument = mockk<DocumentFile> {
+        every { findFile(fileName) } returns staleDocument
+        every { findFile(tmpFileName) } returns null
+        every { findFile(tmpBaseName) } returns null
+        every { createFile("text/csv", tmpBaseName) } returns tmpDocument
+      }
+
+      every { contentResolver.openOutputStream(staleUri, "wt") } returns ByteArrayOutputStream()
+      every { contentResolver.openOutputStream(tmpUri, "wt") } returns ByteArrayOutputStream()
+      every { DocumentsContract.renameDocument(contentResolver, tmpUri, fileName) } returns renamedUri
+
+      val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+      target.write(tree, null, "content") shouldBe renamedUri
+
+      verifyOrder {
+        contentResolver.openOutputStream(tmpUri, "wt")
+        staleDocument.delete()
+        DocumentsContract.renameDocument(contentResolver, tmpUri, fileName)
+      }
+    } finally {
+      unmockkStatic(DocumentsContract::class)
+    }
+  }
+
+  test("does not recreate when length() reports the provider sentinel values 0 or -1") {
+    listOf(0L, -1L).forEach { sentinel ->
+      val tree = treeUri()
+      val contentResolver = mockk<ContentResolver> {
+        every { persistedUriPermissions } returns listOf(grantedPermission(tree))
+      }
+
+      val documentUri = mockk<Uri>()
+      val document = mockk<DocumentFile> {
+        every { uri } returns documentUri
+        every { length() } returns sentinel
+      }
+      val treeDocument = mockk<DocumentFile> { every { findFile(fileName) } returns document }
+      every { contentResolver.openOutputStream(documentUri, "wt") } returns ByteArrayOutputStream()
+
+      val target = AutoExportDocumentWriter(contentResolver, { treeDocument }, { null })
+
+      target.write(tree, null, "content") shouldBe documentUri
+    }
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnablerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnablerTest.kt
@@ -1,0 +1,82 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.ContentResolver
+import android.content.Intent
+import android.net.Uri
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import br.com.colman.petals.settings.SettingsRepository
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+private val grantFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+
+class AutoExportEnablerTest : FunSpec({
+
+  fun newSettingsRepository() = SettingsRepository(
+    PreferenceDataStoreFactory.create { tempfile(suffix = ".preferences_pb") }
+  )
+
+  test("enable() releases any previous grant, takes a new grant, persists it and schedules both jobs") {
+    val settingsRepository = newSettingsRepository()
+    settingsRepository.setAutoExportTreeUri("content://old-tree")
+
+    val contentResolver = mockk<ContentResolver>(relaxed = true)
+    val scheduler = mockk<AutoExportScheduler>(relaxed = true)
+    val oldUri = mockk<Uri>()
+    val newUri = mockk<Uri>()
+    every { newUri.toString() } returns "content://new-tree"
+
+    val target = AutoExportEnabler(contentResolver, settingsRepository, scheduler) { oldUri }
+
+    target.enable(newUri, "My Folder")
+
+    verifyOrder {
+      contentResolver.releasePersistableUriPermission(oldUri, grantFlags)
+      contentResolver.takePersistableUriPermission(newUri, grantFlags)
+      scheduler.schedule()
+      scheduler.exportNow()
+    }
+
+    runBlocking { settingsRepository.autoExportTreeUri.first() } shouldBe "content://new-tree"
+    runBlocking { settingsRepository.autoExportFolderName.first() } shouldBe "My Folder"
+  }
+
+  test("disable() releases the grant, clears settings and cancels both jobs") {
+    val settingsRepository = newSettingsRepository()
+    settingsRepository.setAutoExportTreeUri("content://old-tree")
+
+    val contentResolver = mockk<ContentResolver>(relaxed = true)
+    val scheduler = mockk<AutoExportScheduler>(relaxed = true)
+    val oldUri = mockk<Uri>()
+
+    val target = AutoExportEnabler(contentResolver, settingsRepository, scheduler) { oldUri }
+
+    target.disable()
+
+    verify { contentResolver.releasePersistableUriPermission(oldUri, grantFlags) }
+    verify { scheduler.cancel() }
+    runBlocking { settingsRepository.autoExportTreeUri.first() } shouldBe null
+  }
+
+  test("a SecurityException releasing the previous grant does not propagate") {
+    val settingsRepository = newSettingsRepository()
+    settingsRepository.setAutoExportTreeUri("content://old-tree")
+
+    val contentResolver = mockk<ContentResolver>()
+    val scheduler = mockk<AutoExportScheduler>(relaxed = true)
+    val oldUri = mockk<Uri>()
+    every { contentResolver.releasePersistableUriPermission(any(), any()) } throws SecurityException("gone")
+
+    val target = AutoExportEnabler(contentResolver, settingsRepository, scheduler) { oldUri }
+
+    shouldNotThrowAny { target.disable() }
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnablerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportEnablerTest.kt
@@ -13,15 +13,33 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 private val grantFlags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class AutoExportEnablerTest : FunSpec({
 
   fun newSettingsRepository() = SettingsRepository(
     PreferenceDataStoreFactory.create { tempfile(suffix = ".preferences_pb") }
+  )
+
+  fun enabler(
+    contentResolver: ContentResolver,
+    settingsRepository: SettingsRepository,
+    scheduler: AutoExportScheduler,
+    previousUri: Uri,
+    folderName: String? = "My Folder",
+  ) = AutoExportEnabler(
+    contentResolver = contentResolver,
+    settingsRepository = settingsRepository,
+    scheduler = scheduler,
+    folderNameResolver = { folderName },
+    uriParser = { previousUri },
+    dispatcher = UnconfinedTestDispatcher(),
   )
 
   test("enable() releases any previous grant, takes a new grant, persists it and schedules both jobs") {
@@ -34,19 +52,31 @@ class AutoExportEnablerTest : FunSpec({
     val newUri = mockk<Uri>()
     every { newUri.toString() } returns "content://new-tree"
 
-    val target = AutoExportEnabler(contentResolver, settingsRepository, scheduler) { oldUri }
+    enabler(contentResolver, settingsRepository, scheduler, oldUri).enable(newUri)
 
-    target.enable(newUri, "My Folder")
-
-    verifyOrder {
-      contentResolver.releasePersistableUriPermission(oldUri, grantFlags)
-      contentResolver.takePersistableUriPermission(newUri, grantFlags)
-      scheduler.schedule()
-      scheduler.exportNow()
+    shouldNotThrowAny {
+      verifyOrder {
+        contentResolver.releasePersistableUriPermission(oldUri, grantFlags)
+        contentResolver.takePersistableUriPermission(newUri, grantFlags)
+        scheduler.schedule()
+        scheduler.exportNow()
+      }
     }
 
     runBlocking { settingsRepository.autoExportTreeUri.first() } shouldBe "content://new-tree"
     runBlocking { settingsRepository.autoExportFolderName.first() } shouldBe "My Folder"
+  }
+
+  test("enable() falls back to the Uri when the provider does not report a folder name") {
+    val settingsRepository = newSettingsRepository()
+
+    val scheduler = mockk<AutoExportScheduler>(relaxed = true)
+    val newUri = mockk<Uri>()
+    every { newUri.toString() } returns "content://new-tree"
+
+    enabler(mockk(relaxed = true), settingsRepository, scheduler, mockk(), folderName = null).enable(newUri)
+
+    runBlocking { settingsRepository.autoExportFolderName.first() } shouldBe "content://new-tree"
   }
 
   test("disable() releases the grant, clears settings and cancels both jobs") {
@@ -57,12 +87,12 @@ class AutoExportEnablerTest : FunSpec({
     val scheduler = mockk<AutoExportScheduler>(relaxed = true)
     val oldUri = mockk<Uri>()
 
-    val target = AutoExportEnabler(contentResolver, settingsRepository, scheduler) { oldUri }
+    enabler(contentResolver, settingsRepository, scheduler, oldUri).disable()
 
-    target.disable()
-
-    verify { contentResolver.releasePersistableUriPermission(oldUri, grantFlags) }
-    verify { scheduler.cancel() }
+    shouldNotThrowAny {
+      verify { contentResolver.releasePersistableUriPermission(oldUri, grantFlags) }
+      verify { scheduler.cancel() }
+    }
     runBlocking { settingsRepository.autoExportTreeUri.first() } shouldBe null
   }
 
@@ -72,10 +102,9 @@ class AutoExportEnablerTest : FunSpec({
 
     val contentResolver = mockk<ContentResolver>()
     val scheduler = mockk<AutoExportScheduler>(relaxed = true)
-    val oldUri = mockk<Uri>()
     every { contentResolver.releasePersistableUriPermission(any(), any()) } throws SecurityException("gone")
 
-    val target = AutoExportEnabler(contentResolver, settingsRepository, scheduler) { oldUri }
+    val target = enabler(contentResolver, settingsRepository, scheduler, mockk())
 
     shouldNotThrowAny { target.disable() }
   }

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportModuleTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportModuleTest.kt
@@ -1,0 +1,48 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.content.ContentResolver
+import android.content.Context
+import androidx.work.WorkManager
+import br.com.colman.petals.settings.SettingsRepository
+import br.com.colman.petals.use.io.output.UseCsvSerializer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class AutoExportModuleTest : FunSpec({
+  val koin = koinApplication {
+    modules(
+      AutoExportModule,
+      module {
+        single { mockk<WorkManager>() }
+        single { mockk<ContentResolver>() }
+        single {
+          mockk<Context> {
+            every { contentResolver } returns get()
+          }
+        }
+        single { mockk<SettingsRepository>() }
+        single { mockk<UseCsvSerializer>() }
+      }
+    )
+  }.koin
+
+  test("Should resolve AutoExportDocumentWriter") {
+    koin.get<AutoExportDocumentWriter>() shouldNotBe null
+  }
+
+  test("Should resolve AutoExportScheduler") {
+    koin.get<AutoExportScheduler>() shouldNotBe null
+  }
+
+  test("Should resolve AutoExporter") {
+    koin.get<AutoExporter>() shouldNotBe null
+  }
+
+  test("Should resolve AutoExportEnabler") {
+    koin.get<AutoExportEnabler>() shouldNotBe null
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportSchedulerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportSchedulerTest.kt
@@ -30,6 +30,21 @@ class AutoExportSchedulerTest : FunSpec({
     requestSlot.captured.workSpec.intervalDuration shouldBe DAYS.toMillis(1)
   }
 
+  // Regression: WorkManager runs a periodic request's first iteration immediately. With no
+  // initial delay it races the exportNow() one-shot that enable() fires alongside it, and the
+  // provider dedupes the loser into a stray "PetalsExport (1).csv".
+  test("schedule() delays the first periodic run by a day, so it cannot race exportNow()") {
+    val workManager = mockk<WorkManager>()
+    val requestSlot = slot<PeriodicWorkRequest>()
+    every {
+      workManager.enqueueUniquePeriodicWork("petals-auto-export-daily", KEEP, capture(requestSlot))
+    } returns mockk()
+
+    AutoExportScheduler(workManager).schedule()
+
+    requestSlot.captured.workSpec.initialDelay shouldBe DAYS.toMillis(1)
+  }
+
   test("exportNow() enqueues a one-time request replacing any pending one") {
     val workManager = mockk<WorkManager>()
     every {

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportSchedulerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExportSchedulerTest.kt
@@ -1,0 +1,59 @@
+package br.com.colman.petals.use.io.output.auto
+
+import androidx.work.ExistingPeriodicWorkPolicy.KEEP
+import androidx.work.ExistingWorkPolicy.REPLACE
+import androidx.work.NetworkType.NOT_REQUIRED
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkManager
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.util.concurrent.TimeUnit.DAYS
+
+class AutoExportSchedulerTest : FunSpec({
+
+  test("schedule() enqueues a 24h periodic request with KEEP and no network constraint") {
+    val workManager = mockk<WorkManager>()
+    val requestSlot = slot<PeriodicWorkRequest>()
+    every {
+      workManager.enqueueUniquePeriodicWork("petals-auto-export-daily", KEEP, capture(requestSlot))
+    } returns mockk()
+
+    AutoExportScheduler(workManager).schedule()
+
+    requestSlot.captured.workSpec.constraints.requiredNetworkType shouldBe NOT_REQUIRED
+    requestSlot.captured.workSpec.intervalDuration shouldBe DAYS.toMillis(1)
+  }
+
+  test("exportNow() enqueues a one-time request replacing any pending one") {
+    val workManager = mockk<WorkManager>()
+    every {
+      workManager.enqueueUniqueWork("petals-auto-export-now", REPLACE, any<OneTimeWorkRequest>())
+    } returns mockk()
+
+    AutoExportScheduler(workManager).exportNow()
+
+    shouldNotThrowAny {
+      verify { workManager.enqueueUniqueWork("petals-auto-export-now", REPLACE, any<OneTimeWorkRequest>()) }
+    }
+  }
+
+  test("cancel() cancels both the periodic and one-time unique work names") {
+    val workManager = mockk<WorkManager>()
+    every { workManager.cancelUniqueWork(any<String>()) } returns mockk()
+
+    AutoExportScheduler(workManager).cancel()
+
+    shouldNotThrowAny {
+      verify {
+        workManager.cancelUniqueWork("petals-auto-export-daily")
+        workManager.cancelUniqueWork("petals-auto-export-now")
+      }
+    }
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExporterTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/io/output/auto/AutoExporterTest.kt
@@ -1,0 +1,82 @@
+package br.com.colman.petals.use.io.output.auto
+
+import android.net.Uri
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import br.com.colman.petals.settings.SettingsRepository
+import br.com.colman.petals.use.io.output.UseCsvSerializer
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.tempfile
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.io.IOException
+
+class AutoExporterTest : FunSpec({
+
+  fun newSettingsRepository() = SettingsRepository(
+    PreferenceDataStoreFactory.create { tempfile(suffix = ".preferences_pb") }
+  )
+
+  val fakeUri = mockk<Uri>()
+  val uriParser: (String) -> Uri = { fakeUri }
+
+  test("returns Success and never touches the writer when no tree Uri is configured") {
+    val settingsRepository = newSettingsRepository()
+    val target = AutoExporter(settingsRepository, mockk(), mockk(), uriParser)
+
+    runBlocking { target.export() } shouldBe AutoExportResult.Success
+  }
+
+  test("records the document Uri and success timestamp, and clears the error, on success") {
+    val settingsRepository = newSettingsRepository()
+    settingsRepository.setAutoExportTreeUri("content://tree")
+    settingsRepository.setAutoExportLastError("io")
+
+    val serializer = mockk<UseCsvSerializer>()
+    val writer = mockk<AutoExportDocumentWriter>()
+    val resultUri = mockk<Uri>()
+    every { resultUri.toString() } returns "content://tree/PetalsExport.csv"
+
+    coEvery { serializer.computeUseCsv() } returns "csv"
+    every { writer.write(any(), any(), "csv") } returns resultUri
+
+    val target = AutoExporter(settingsRepository, serializer, writer, uriParser)
+
+    runBlocking { target.export() } shouldBe AutoExportResult.Success
+    runBlocking { settingsRepository.autoExportDocumentUri.first() } shouldBe "content://tree/PetalsExport.csv"
+    runBlocking { settingsRepository.autoExportLastError.first() } shouldBe null
+  }
+
+  test("maps SecurityException to PermissionLost and records the permission error") {
+    val settingsRepository = newSettingsRepository()
+    settingsRepository.setAutoExportTreeUri("content://tree")
+
+    val serializer = mockk<UseCsvSerializer>()
+    val writer = mockk<AutoExportDocumentWriter>()
+    coEvery { serializer.computeUseCsv() } returns "csv"
+    every { writer.write(any(), any(), any()) } throws SecurityException("gone")
+
+    val target = AutoExporter(settingsRepository, serializer, writer, uriParser)
+
+    runBlocking { target.export() } shouldBe AutoExportResult.PermissionLost
+    runBlocking { settingsRepository.autoExportLastError.first() } shouldBe "permission"
+  }
+
+  test("maps IOException to Transient and records the io error") {
+    val settingsRepository = newSettingsRepository()
+    settingsRepository.setAutoExportTreeUri("content://tree")
+
+    val serializer = mockk<UseCsvSerializer>()
+    val writer = mockk<AutoExportDocumentWriter>()
+    coEvery { serializer.computeUseCsv() } returns "csv"
+    every { writer.write(any(), any(), any()) } throws IOException("offline")
+
+    val target = AutoExporter(settingsRepository, serializer, writer, uriParser)
+
+    runBlocking { target.export() } shouldBe AutoExportResult.Transient
+    runBlocking { settingsRepository.autoExportLastError.first() } shouldBe "io"
+  }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 datastore = "1.2.1"
 compose = "1.11.4"
 detekt = "1.23.8"
+documentfile = "1.1.0"
 glance = "1.1.1"
 koin = "4.2.2"
 kotest = "6.2.2"
@@ -11,6 +12,7 @@ vanpra-material-dialogs = "0.9.0"
 sqldelight = "2.3.2"
 mockk = "1.14.11"
 review = "2.0.2"
+work = "2.10.1"
 
 [libraries]
 android-desugar-jdk = "com.android.tools:desugar_jdk_libs:2.1.5"
@@ -34,7 +36,7 @@ koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = 
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest" }
-kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.2" }
+kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.3" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
 kotlin-csv = "com.jsoizo:kotlin-csv:1.11.0"
@@ -62,6 +64,8 @@ play-services-billing = "com.android.billingclient:billing:8.3.0"
 fuel = "com.github.kittinunf.fuel:fuel:2.3.1"
 androidx-test-core = "androidx.test:core:1.7.0"
 review = { module = "com.google.android.play:review", version.ref = "review" }
+androidx-work = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
 
 
 [bundles]


### PR DESCRIPTION
Closes #100.

## What

Adds an **Automatic daily export** toggle to Settings. Flip it on, the system folder picker opens, and you choose a destination. Petals writes `PetalsExport.csv` there right away, then re-writes that same file about once a day, overwriting it in place.

The destination is a SAF tree Uri rather than a path, so **any** DocumentsProvider works — including cloud-synced folders like Nextcloud, which then take care of versioning and off-device durability for free. The row shows the folder name and the last export time, and toggling off releases the persisted permission grant.

The file is the existing uses-only CSV (`UseCsvSerializer`, reused unchanged), so it still round-trips through the Import button.

## Design notes

**No new permissions and no manifest change.** WorkManager was already on the runtime classpath transitively via Glance — its initializer and `RescheduleReceiver` are already in the merged manifest — so reboot survival comes for free.

**The worker must use `Constraints.NONE`.** The fdroid flavor removes `ACCESS_NETWORK_STATE` from the manifest, so a `NetworkType` constraint would throw `SecurityException` at runtime *on fdroid only*, past every CI check. `AutoExportSchedulerTest` asserts the constraint stays `NOT_REQUIRED` so nobody can quietly reintroduce it.

**`openOutputStream(uri, "wt")` is not guaranteed to truncate.** The SAF contract only promises `w`; a provider may ignore the `t`. Left unhandled, a shorter CSV would leave the tail of yesterday's longer one glued onto the end. `AutoExportDocumentWriter` verifies the written length and, if truncation was ignored, rewrites via a tmp sibling *before* deleting the stale file — never delete-then-create, so a crash mid-way leaves yesterday's file intact rather than a hole.

**`createFile()` is given the name without its extension.** Providers derive the extension from the MIME type and append it themselves; passing `"PetalsExport.csv"` produces `PetalsExport.csv.csv` on a raw-backed provider, after which `findFile` misses and `createFile` refuses to clobber the existing file — breaking every export after the first. This was caught by the instrumented test, not by the mocked unit tests.

## Verification

`./gradlew test detekt licensee` is green. 23 new tests.

Driven end-to-end on an emulator, not just tested:

- Picking a folder persists the grant; the file appears within seconds.
- The daily job is genuinely registered with the OS (visible in `dumpsys jobscheduler`).
- With 60 uses in the database it rewrote the *same* file to 5441 bytes — no `PetalsExport (1).csv` duplicate.
- Shrinking the database to 2 uses and re-exporting produced a file of exactly 235 bytes, with none of the previous 5441 trailing on the end. This was the failure mode most likely to silently corrupt exports.
- Toggling off releases the persisted grant.

The recreate fallback itself was not exercised at runtime — the emulator's provider honours `"wt"` properly, so the write took the happy path. It is covered by unit tests only; certainty against Nextcloud specifically needs a run on a real device with it installed.

## Drive-by

Bumps `kotest-runner-android` 1.2.2 → 1.2.3. 1.2.2 is built against an older Kotest engine than the 6.2.2 this project uses, and **every** instrumented test — including the pre-existing `KoinModuleTest` — died in `NoSuchMethodError: Materializer.materialize` before running a single assertion. With 1.2.3 they execute again.

Two instrumented tests still fail, both pre-existing and unrelated (and CI runs no `connectedAndroidTest`): `ComposeHitTimerTest` asserts a milliseconds display that requires a setting which defaults to off, and `ScreenshotTakerTest` is the store-screenshot uploader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Er77vGxgVjcBVRMLVJciS