### PR TITLE
🐛 Fix release-only startup crash: R8 strips Room's WorkDatabase constructor

### DIFF
--- a/app/proguard-android-optimize.txt
+++ b/app/proguard-android-optimize.txt
@@ -3,6 +3,18 @@
     public static **[] values();
     public static ** valueOf(java.lang.String);
 }
+
+# Room builds its generated *_Impl reflectively, so the no-arg constructor has no
+# caller R8 can see. room-runtime 2.2.5 (pulled in transitively: Glance -> WorkManager
+# -> Room) ships the old consumer rule "-keep class * extends androidx.room.RoomDatabase",
+# which keeps the class but NOT its members, so R8 dropped WorkDatabase_Impl.<init>().
+# Room then failed to instantiate it, androidx.startup.InitializationProvider blew up, and
+# every release build crashed on launch before reaching any of our code. Debug builds are
+# not minified, which is why this only ever showed up in the wild.
+# Newer Room ships this exact rule itself; keep it here until the dependency catches up.
+-keep class * extends androidx.room.RoomDatabase {
+    <init>();
+}
 -keep class * implements android.os.Parcelable {
   public static final android.os.Parcelable$Creator *;
 }


### PR DESCRIPTION
**Every minified build crashes on launch**, before reaching any of our code:

```
java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider
Caused by: java.lang.RuntimeException: Failed to create an instance of androidx.work.impl.WorkDatabase
```

## Root cause

Glance pulls in WorkManager, which uses Room. The version that resolves is **room-runtime 2.2.5**, whose consumer ProGuard rule is the old form:

```
-keep class * extends androidx.room.RoomDatabase
```

That keeps the *class* but **not its members**. Room constructs the generated `WorkDatabase_Impl` reflectively, so its no-arg constructor has no caller R8 can see — and R8 removed it. Straight from the release build's own `usage.txt` (the list of things R8 stripped):

```
androidx.work.impl.WorkDatabase_Impl:
    public void <init>()
```

Room then throws `InstantiationException`, WorkManager's initializer fails, and `androidx.startup.InitializationProvider` takes the process down at bind time.

Debug builds are not minified, which is why this only ever showed up in the wild and never in CI.

## Fix

Add the members-preserving rule that newer Room ships itself:

```
-keep class * extends androidx.room.RoomDatabase {
    <init>();
}
```

## Verification

Built `fdroidRelease`, signed it, installed and launched on a device:

- **Before**: the reported crash reproduces exactly — `FATAL EXCEPTION: main`, `Unable to get provider androidx.startup.InitializationProvider`.
- **After**: `WorkDatabase_Impl.<init>()` is gone from `usage.txt`'s removed list, the app starts, and the UI renders (all five tabs present).

## Note

This is independent of #1105 (auto-export), but worth knowing: that PR makes WorkManager *load-bearing* rather than merely present, and it upgrades `work-runtime` to 2.10.1, which brings a Room new enough to carry the correct rule on its own. This hotfix is the right fix regardless — it stands on its own and should go in first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Er77vGxgVjcBVRMLVJciS