### PR TITLE
✨ Base withdrawal timing on intake, not just last use

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsRepository.kt
@@ -56,6 +56,7 @@ class SettingsRepository(
   val isHourOfDayLineInStatsEnabled = datastore.data.map { it[IsHourOfDayLineInStatsEnabled] ?: false }
   val isBreakPeriodInStatsEnabled = datastore.data.map { it[IsBreakPeriodInStatsEnabled] ?: true }
   val isIgnoringLongestDailyDelay = datastore.data.map { it[IsIgnoringLongestDailyDelay] ?: false }
+  val isToleranceModelEnabled = datastore.data.map { it[IsToleranceModelEnabled] ?: true }
   val isDayExtended = datastore.data.map { it[IsDayExtended] ?: false }
   val appLanguages = AppLanguage.entries.map { it.languageName }
 
@@ -112,6 +113,10 @@ class SettingsRepository(
     datastore.edit { it[IsIgnoringLongestDailyDelay] = value }
   }
 
+  fun setIsToleranceModelEnabled(value: Boolean): Unit = runBlocking {
+    datastore.edit { it[IsToleranceModelEnabled] = value }
+  }
+
   companion object {
     val CurrencyIcon = stringPreferencesKey("currency_icon")
     val DateFormat = stringPreferencesKey("date_format")
@@ -125,5 +130,6 @@ class SettingsRepository(
     val IsHourOfDayLineInStatsEnabled = booleanPreferencesKey("is_hour_of_day_line_in_stats_enabled")
     val IsBreakPeriodInStatsEnabled = booleanPreferencesKey("is_break_period_in_stats_enabled")
     val IsIgnoringLongestDailyDelay = booleanPreferencesKey("is_ignoring_longest_daily_delay")
+    val IsToleranceModelEnabled = booleanPreferencesKey("is_tolerance_model_enabled")
   }
 }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/SettingsView.kt
@@ -24,6 +24,7 @@ import br.com.colman.petals.settings.view.listitem.ShareApp
 import br.com.colman.petals.settings.view.listitem.TimeListItem
 import br.com.colman.petals.statistics.view.listitem.BreakPeriodInStatsEnabledListItem
 import br.com.colman.petals.statistics.view.listitem.HourOfDayLineInStatsEnabledListItem
+import br.com.colman.petals.withdrawal.view.listitem.ToleranceModelEnabledListItem
 
 @Composable
 fun SettingsView(settingsRepository: SettingsRepository) {
@@ -46,6 +47,7 @@ fun SettingsView(settingsRepository: SettingsRepository) {
 
   val currentHourOfDayInLineStatsEnabled by settingsRepository.isHourOfDayLineInStatsEnabled.collectAsState(true)
   val currentBreakPeriodInStatsEnabled by settingsRepository.isBreakPeriodInStatsEnabled.collectAsState(true)
+  val currentToleranceModelEnabled by settingsRepository.isToleranceModelEnabled.collectAsState(true)
 
   Column(Modifier.verticalScroll(rememberScrollState())) {
     CurrencyListItem(currentCurrency, settingsRepository::setCurrencyIcon)
@@ -76,6 +78,10 @@ fun SettingsView(settingsRepository: SettingsRepository) {
     BreakPeriodInStatsEnabledListItem(
       currentBreakPeriodInStatsEnabled,
       settingsRepository::setIsBreakPeriodInStatsEnabled
+    )
+    ToleranceModelEnabledListItem(
+      currentToleranceModelEnabled,
+      settingsRepository::setIsToleranceModelEnabled
     )
     ShareApp()
   }

--- a/app/src/main/kotlin/br/com/colman/petals/use/repository/UseRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/use/repository/UseRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
+import java.time.LocalDateTime
 import java.time.LocalDateTime.parse
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
 import br.com.colman.petals.Use as UseEntity
@@ -39,6 +40,14 @@ class UseRepository(
   fun all(dispatchers: CoroutineDispatcher = IO): Flow<List<Use>> = useQueries.selectAll().asFlow().mapToList(
     dispatchers
   ).map { it.map(UseEntity::toUse) }
+
+  /**
+   * Uses from [from] up to now, oldest first. Future-dated rows are excluded, matching [getLastUse].
+   * Callers that only need a recent window should prefer this over [all], which materialises every row.
+   */
+  fun since(from: LocalDateTime, dispatcher: CoroutineDispatcher = IO): Flow<List<Use>> =
+    useQueries.selectSince(from.format(ISO_LOCAL_DATE_TIME)).asFlow().mapToList(dispatcher)
+      .map { it.map(UseEntity::toUse) }
 
   fun delete(use: Use) {
     Timber.d("Deleting use: $use")

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/SymptomsPage.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/SymptomsPage.kt
@@ -25,32 +25,78 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import br.com.colman.petals.R.plurals.amount_days
+import br.com.colman.petals.R.string.effective_abstinence_disabled
+import br.com.colman.petals.R.string.effective_abstinence_explained
+import br.com.colman.petals.R.string.effective_abstinence_sessions_mode
+import br.com.colman.petals.R.string.effective_abstinence_unavailable
 import br.com.colman.petals.R.string.symptoms_introduction
+import br.com.colman.petals.settings.SettingsRepository
 import br.com.colman.petals.use.repository.UseRepository
 import br.com.colman.petals.withdrawal.data.ChartConfig
+import br.com.colman.petals.withdrawal.tolerance.AbstinenceEstimate
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Disabled
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Grams
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.LastUseOnly
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Sessions
+import br.com.colman.petals.withdrawal.tolerance.ToleranceLookbackDays
+import br.com.colman.petals.withdrawal.tolerance.estimateAbstinence
+import br.com.colman.petals.withdrawal.view.SecondsPerDay
 import br.com.colman.petals.withdrawal.view.WithdrawalChart
+import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
+import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.math.roundToInt
+import kotlin.time.Duration.Companion.minutes
 
 @Composable
-fun SymptomsPage(useRepository: UseRepository = koinInject()) {
-  val lastUseDate by useRepository.getLastUseDate().collectAsState(null)
+fun SymptomsPage(
+  useRepository: UseRepository = koinInject(),
+  settingsRepository: SettingsRepository = koinInject()
+) {
+  // Pinned to a day boundary so the query, and therefore the subscription, stays stable while the tab is open.
+  val windowStart = remember { LocalDate.now().minusDays(ToleranceLookbackDays).atStartOfDay() }
+  val usesFlow = remember(windowStart) { useRepository.since(windowStart) }
 
-  SymptomsOverview(lastUseDate)
+  val uses by usesFlow.collectAsState(emptyList())
+  val lastUseDate by useRepository.getLastUseDate().collectAsState(null)
+  val isToleranceModelEnabled by settingsRepository.isToleranceModelEnabled.collectAsState(true)
+
+  var now by remember { mutableStateOf(LocalDateTime.now()) }
+  LaunchedEffect(Unit) {
+    while (true) {
+      delay(1.minutes)
+      now = LocalDateTime.now()
+    }
+  }
+
+  val estimate = remember(uses, lastUseDate, isToleranceModelEnabled, now) {
+    estimateAbstinence(uses, lastUseDate, now, isToleranceModelEnabled)
+  }
+
+  SymptomsOverview(estimate)
 }
 
 @Composable
 @Preview
 private fun SymptomsPreview() {
-  SymptomsOverview(LocalDateTime.now().minusDays(10))
+  SymptomsOverview(AbstinenceEstimate(Duration.ofDays(10), Duration.ofHours(2), Grams))
 }
 
 @Composable
@@ -60,25 +106,61 @@ private fun SymptomsNullPreview() {
 }
 
 @Composable
-private fun SymptomsOverview(lastUseDate: LocalDateTime?) {
+private fun SymptomsOverview(estimate: AbstinenceEstimate?) {
   Column(Modifier.verticalScroll(rememberScrollState()).padding(8.dp, 8.dp, 8.dp, 64.dp), spacedBy(16.dp)) {
     Text(stringResource(symptoms_introduction))
-    ChartList(lastUseDate)
+    AbstinenceExplanation(estimate)
+    ChartList(estimate?.effective)
+  }
+}
+
+/**
+ * Both numbers, always. A relapse can leave the effective reading far above the literal time since the
+ * last use, and the Usage tab keeps showing the literal one, so hiding it would read as a contradiction.
+ */
+@Composable
+private fun AbstinenceExplanation(estimate: AbstinenceEstimate?) {
+  if (estimate == null) return
+
+  Column(verticalArrangement = spacedBy(4.dp)) {
+    val fallbackReason = when (estimate.mode) {
+      LastUseOnly -> effective_abstinence_unavailable
+      Disabled -> effective_abstinence_disabled
+      else -> null
+    }
+    if (fallbackReason != null) {
+      Text(stringResource(fallbackReason), style = MaterialTheme.typography.caption)
+      return@Column
+    }
+
+    Text(
+      stringResource(effective_abstinence_explained, estimate.effective.asDays(), estimate.actual.asDays()),
+      style = MaterialTheme.typography.caption
+    )
+    if (estimate.mode == Sessions) {
+      Text(stringResource(effective_abstinence_sessions_mode), style = MaterialTheme.typography.caption)
+    }
   }
 }
 
 @Composable
-private fun ChartList(lastUseDate: LocalDateTime?) {
+private fun Duration.asDays(): String {
+  val days = seconds.toDouble() / SecondsPerDay
+  return pluralStringResource(amount_days, days.roundToInt(), "%.1f".format(days))
+}
+
+@Composable
+private fun ChartList(effectiveAbstinence: Duration?) {
   ChartConfig.entries().forEach { chartConfig ->
-    WithdrawalChartBox(chartConfig, lastUseDate)
+    WithdrawalChartBox(chartConfig, effectiveAbstinence)
   }
 }
 
 @Composable
-private fun WithdrawalChartBox(chartConfig: ChartConfig, lastUseDate: LocalDateTime?) {
+private fun WithdrawalChartBox(chartConfig: ChartConfig, effectiveAbstinence: Duration?) {
   Box(Modifier.height(250.dp)) {
     WithdrawalChart(
-      lastUseDate = lastUseDate,
+      effectiveAbstinence = effectiveAbstinence,
       data = chartConfig.data,
       graphTitle = { getString(chartConfig.title, "%.2f".format(it ?: 0.0)) },
       verticalAxisTitle = stringResource(chartConfig.verticalAxisTitle),

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/SymptomsPage.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/SymptomsPage.kt
@@ -146,7 +146,9 @@ private fun AbstinenceExplanation(estimate: AbstinenceEstimate?) {
 @Composable
 private fun Duration.asDays(): String {
   val days = seconds.toDouble() / SecondsPerDay
-  return pluralStringResource(amount_days, days.roundToInt(), "%.1f".format(days))
+  val rounded = (days * 10).roundToInt() / 10.0
+  val quantity = if (rounded == 1.0) 1 else 2
+  return pluralStringResource(amount_days, quantity, "%.1f".format(rounded))
 }
 
 @Composable

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/SymptomsPage.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/SymptomsPage.kt
@@ -53,9 +53,9 @@ import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Disabled
 import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Grams
 import br.com.colman.petals.withdrawal.tolerance.EstimateMode.LastUseOnly
 import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Sessions
+import br.com.colman.petals.withdrawal.tolerance.SecondsPerDay
 import br.com.colman.petals.withdrawal.tolerance.ToleranceLookbackDays
 import br.com.colman.petals.withdrawal.tolerance.estimateAbstinence
-import br.com.colman.petals.withdrawal.view.SecondsPerDay
 import br.com.colman.petals.withdrawal.view.WithdrawalChart
 import kotlinx.coroutines.delay
 import org.koin.compose.koinInject

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/interpolator/Interpolator.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/interpolator/Interpolator.kt
@@ -15,9 +15,12 @@ class Interpolator(
     data.values.toDoubleArray()
   )
 
+  private val minPossibleX = data.keys.min().seconds
   private val maxPossibleX = data.keys.max().seconds
 
   override fun interpolate(xs: DoubleArray?, ys: DoubleArray?): UnivariateFunction = dataInterpolator
 
-  override fun value(x: Double): Double = dataInterpolator.value(x.coerceAtMost(maxPossibleX.toDouble()))
+  /** Clamped at both ends: the spline throws outside its knots, and the THC curve starts at day 0. */
+  override fun value(x: Double): Double =
+    dataInterpolator.value(x.coerceIn(minPossibleX.toDouble(), maxPossibleX.toDouble()))
 }

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/AbstinenceEstimate.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/AbstinenceEstimate.kt
@@ -1,0 +1,28 @@
+package br.com.colman.petals.withdrawal.tolerance
+
+import java.time.Duration
+
+/** Which currency the tolerance model was able to run in, or that it could not run at all. */
+enum class EstimateMode {
+  /** Logged amounts were used as doses. */
+  Grams,
+
+  /** Amounts were mostly missing, so each logged use counted as one session. */
+  Sessions,
+
+  /** Not enough history to compare against: the reading is plain time since the last use. */
+  LastUseOnly,
+
+  /** The user turned the tolerance adjustment off. Same reading as [LastUseOnly], different reason. */
+  Disabled
+}
+
+/**
+ * @param effective where the withdrawal curves are read, accounting for how much the user has been using
+ * @param actual literal time since the last logged use, which the Usage tab also shows
+ */
+data class AbstinenceEstimate(
+  val effective: Duration,
+  val actual: Duration,
+  val mode: EstimateMode
+)

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeries.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeries.kt
@@ -17,9 +17,6 @@ const val MinDosesForModel = 3
 /** Fraction of the window's uses that must carry an amount before amounts are trusted as doses. */
 const val GramsCoverageThreshold = 0.80
 
-/** Amounts above this are treated as a typo (280 for 2.8) and capped, so one row cannot pin the reading. */
-const val MaxPlausibleDoseGrams = 100.0
-
 /**
  * Turns the raw use history into the number the withdrawal curves are read at.
  *
@@ -27,8 +24,8 @@ const val MaxPlausibleDoseGrams = 100.0
  * - **Grams** when the window has enough uses and most of them record an amount.
  * - **Sessions** when amounts are mostly missing. Burden is proportional to how often the user logs, so
  *   eight sessions a day dropping to one still reads as ln(8)/lambda, exactly as eight grams to one would.
- * - **LastUseOnly** otherwise, or when the model is switched off: literal time since the last use, which
- *   is what the app did before tolerance was modelled.
+ * - **LastUseOnly** otherwise, and **Disabled** when the user switched the adjustment off: both read the
+ *   literal time since the last use, which is what the app did before tolerance was modelled.
  *
  * Returns null when there is no use at all to anchor on.
  */
@@ -38,7 +35,7 @@ fun estimateAbstinence(
   now: LocalDateTime,
   modelEnabled: Boolean
 ): AbstinenceEstimate? {
-  val actual = lastUseDate?.let { elapsedSince(it, now) } ?: return null
+  val actual = lastUseDate?.elapsedUntil(now) ?: return null
 
   val modelled = if (modelEnabled) modelledAbstinence(uses, now) else null
   val fallback = if (modelEnabled) LastUseOnly else Disabled
@@ -64,13 +61,15 @@ private fun modelledAbstinence(uses: List<Use>, now: LocalDateTime): Pair<Durati
 }
 
 /**
- * The logged amount as a usable dose, or 0.0 when it is missing, negative or not a finite number.
- * An empty amount field is stored as zero rather than rejected, so this is a common shape, not an edge.
+ * The logged amount as a usable dose, taken at face value, or 0.0 when it is missing, negative or not a
+ * finite number. An empty amount field is stored as zero rather than rejected, so that is a common shape
+ * here, not an edge case.
  */
 private fun Use.sanitizedAmount(): Double {
   val grams = amountGrams.toDouble()
-  return if (grams.isFinite() && grams > 0.0) grams.coerceAtMost(MaxPlausibleDoseGrams) else 0.0
+  return if (grams.isFinite() && grams > 0.0) grams else 0.0
 }
 
-private fun elapsedSince(date: LocalDateTime, now: LocalDateTime) =
-  if (date.isAfter(now)) Duration.ZERO else Duration.between(date, now)
+/** Time from this instant until [now], or zero if this is in the future. */
+private fun LocalDateTime.elapsedUntil(now: LocalDateTime): Duration =
+  if (isAfter(now)) Duration.ZERO else Duration.between(this, now)

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeries.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeries.kt
@@ -1,0 +1,76 @@
+package br.com.colman.petals.withdrawal.tolerance
+
+import br.com.colman.petals.use.repository.Use
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Disabled
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Grams
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.LastUseOnly
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Sessions
+import java.time.Duration
+import java.time.LocalDateTime
+
+/** How far back uses are read. Only a data volume bound: the tolerance release already fades old peaks. */
+const val ToleranceLookbackDays = 90L
+
+/** Below this many logged uses in the window there is nothing to compare a reduction against. */
+const val MinDosesForModel = 3
+
+/** Fraction of the window's uses that must carry an amount before amounts are trusted as doses. */
+const val GramsCoverageThreshold = 0.80
+
+/** Amounts above this are treated as a typo (280 for 2.8) and capped, so one row cannot pin the reading. */
+const val MaxPlausibleDoseGrams = 100.0
+
+/**
+ * Turns the raw use history into the number the withdrawal curves are read at.
+ *
+ * Three tiers, in order:
+ * - **Grams** when the window has enough uses and most of them record an amount.
+ * - **Sessions** when amounts are mostly missing. Burden is proportional to how often the user logs, so
+ *   eight sessions a day dropping to one still reads as ln(8)/lambda, exactly as eight grams to one would.
+ * - **LastUseOnly** otherwise, or when the model is switched off: literal time since the last use, which
+ *   is what the app did before tolerance was modelled.
+ *
+ * Returns null when there is no use at all to anchor on.
+ */
+fun estimateAbstinence(
+  uses: List<Use>,
+  lastUseDate: LocalDateTime?,
+  now: LocalDateTime,
+  modelEnabled: Boolean
+): AbstinenceEstimate? {
+  val actual = lastUseDate?.let { elapsedSince(it, now) } ?: return null
+
+  val modelled = if (modelEnabled) modelledAbstinence(uses, now) else null
+  val fallback = if (modelEnabled) LastUseOnly else Disabled
+  return modelled?.let { (effective, mode) -> AbstinenceEstimate(effective, actual, mode) }
+    ?: AbstinenceEstimate(actual, actual, fallback)
+}
+
+/** The tolerance-adjusted reading and the currency it was computed in, or null when it cannot be run. */
+private fun modelledAbstinence(uses: List<Use>, now: LocalDateTime): Pair<Duration, EstimateMode>? {
+  val window = uses.filter { !it.date.isAfter(now) && !it.date.isBefore(now.minusDays(ToleranceLookbackDays)) }
+  if (window.size < MinDosesForModel) return null
+
+  val amounts = window.map { it.sanitizedAmount() }
+  val coverage = amounts.count { it > 0.0 }.toDouble() / amounts.size
+
+  val mode = if (coverage >= GramsCoverageThreshold) Grams else Sessions
+  val doses = when (mode) {
+    Grams -> window.zip(amounts).filter { (_, amount) -> amount > 0.0 }.map { (use, amount) -> Dose(use.date, amount) }
+    else -> window.map { Dose(it.date, 1.0) }
+  }
+
+  return effectiveAbstinence(doses, now)?.let { it to mode }
+}
+
+/**
+ * The logged amount as a usable dose, or 0.0 when it is missing, negative or not a finite number.
+ * An empty amount field is stored as zero rather than rejected, so this is a common shape, not an edge.
+ */
+private fun Use.sanitizedAmount(): Double {
+  val grams = amountGrams.toDouble()
+  return if (grams.isFinite() && grams > 0.0) grams.coerceAtMost(MaxPlausibleDoseGrams) else 0.0
+}
+
+private fun elapsedSince(date: LocalDateTime, now: LocalDateTime) =
+  if (date.isAfter(now)) Duration.ZERO else Duration.between(date, now)

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurden.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurden.kt
@@ -38,7 +38,8 @@ const val ToleranceReleasePerDay = 0.033
  */
 const val MaxEffectiveAbstinenceDays = 30.0
 
-private const val SecondsPerDay = 86_400.0
+/** Single source of truth for the day/second conversion used by the model, the charts and their tests. */
+const val SecondsPerDay = 86_400
 
 /** A single logged intake: [amount] is grams in grams mode, or 1.0 per session in sessions mode. */
 data class Dose(val at: LocalDateTime, val amount: Double)
@@ -114,6 +115,12 @@ private fun burdenAtEachDose(ordered: List<Dose>, lambda: Double): DoubleArray {
   return burdens
 }
 
-private fun daysBetween(from: LocalDateTime, to: LocalDateTime) = SECONDS.between(from, to) / SecondsPerDay
+private fun daysBetween(from: LocalDateTime, to: LocalDateTime) =
+  SECONDS.between(from, to).toDouble() / SecondsPerDay
 
+/**
+ * Rounded to the nearest **second**, not to the nearest day: sub-day resolution is the whole point here.
+ * A user who cut down yesterday reads a fraction of a day, and the charts interpolate continuously, so
+ * [Duration.ofDays] would collapse exactly the detail this feature exists to show.
+ */
 private fun Double.daysAsDuration() = Duration.ofSeconds((this * SecondsPerDay).roundToLong())

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurden.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurden.kt
@@ -1,0 +1,119 @@
+package br.com.colman.petals.withdrawal.tolerance
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit.SECONDS
+import kotlin.math.exp
+import kotlin.math.ln
+import kotlin.math.roundToLong
+
+/**
+ * Elimination rate of the creatinine-normalized THC metabolite, per day.
+ *
+ * Derived by log-linear regression over [br.com.colman.petals.withdrawal.data.ThcConcentrationDataPoints],
+ * days 0 to 14. The day-20 point is excluded because it is 0.0 and ln(0) is undefined.
+ * Half-life is ln(2)/lambda = 4.594 days, which sits inside the 4 to 13 day range reported for
+ * THC-COOH terminal elimination in chronic users.
+ *
+ * Do not fit this over a shorter range: truncating at day 7 yields a 3.0 day half-life, and lambda is
+ * load bearing (the steady state reading for a k-fold reduction in intake is exactly ln(k)/lambda).
+ *
+ * @see br.com.colman.petals.withdrawal.tolerance.ThcDecayConstantTest which re-derives it from the data.
+ */
+const val ThcEliminationPerDay = 0.150864744989
+
+/**
+ * Rate at which a past peak stops counting as the user's tolerance, per day. Half-life of 21 days.
+ *
+ * This is a tuning constant, not a measured one. It expresses the assumption that tolerance readjusts
+ * to a sustained lower intake over a few weeks. Without it, a user who permanently cut their intake
+ * eightfold would read ln(8)/lambda = 13.8 days into withdrawal forever, and an isolated binge would
+ * keep a stable user flagged for as long as it stayed inside the lookback window.
+ */
+const val ToleranceReleasePerDay = 0.033
+
+/**
+ * The longest abstinence the model will ever claim, in days. Above the widest chart (25 days), and it
+ * doubles as the clamp that keeps `-ln(ratio)` finite when the current burden rounds to nothing.
+ */
+const val MaxEffectiveAbstinenceDays = 30.0
+
+private const val SecondsPerDay = 86_400.0
+
+/** A single logged intake: [amount] is grams in grams mode, or 1.0 per session in sessions mode. */
+data class Dose(val at: LocalDateTime, val amount: Double)
+
+/**
+ * Body burden at [instant]: the superposition of every dose decaying at [lambda].
+ * Doses after [instant] are ignored, so a future-dated entry can never produce e^(+lambda*t).
+ */
+fun burdenAt(doses: List<Dose>, instant: LocalDateTime, lambda: Double = ThcEliminationPerDay): Double =
+  doses.filter { !it.at.isAfter(instant) }
+    .sumOf { it.amount * exp(-lambda * daysBetween(it.at, instant)) }
+
+/**
+ * The highest burden the user reached, with older peaks released at [tolerance].
+ *
+ * The release is measured from the most recent dose rather than from now, which is what keeps the model
+ * exact for someone who simply stopped: their last dose is its own reference and is released by nothing,
+ * so the peak cancels and the result is precisely the elapsed time since it. See [effectiveAbstinence].
+ */
+fun referenceBurden(
+  doses: List<Dose>,
+  lambda: Double = ThcEliminationPerDay,
+  tolerance: Double = ToleranceReleasePerDay
+): Double {
+  val ordered = doses.sortedBy { it.at }
+  if (ordered.isEmpty()) return 0.0
+
+  val lastDose = ordered.last().at
+  val burdens = burdenAtEachDose(ordered, lambda)
+  return ordered.indices.maxOf { index ->
+    burdens[index] * exp(-tolerance * daysBetween(ordered[index].at, lastDose))
+  }
+}
+
+/**
+ * How long ago a user with this history would have had today's body burden, had they simply stopped.
+ *
+ * This is the number the withdrawal curves are read at. For someone who quit outright it equals the time
+ * since their last use, exactly, whatever their dosing cadence was. For someone who cut down it lags real
+ * time, which is the point: an ounce a day dropped to an eighth is not "day zero" of withdrawal.
+ *
+ * Returns null when the model has nothing to work with (no usable doses), so the caller can fall back.
+ */
+fun effectiveAbstinence(
+  doses: List<Dose>,
+  now: LocalDateTime,
+  lambda: Double = ThcEliminationPerDay,
+  tolerance: Double = ToleranceReleasePerDay
+): Duration? {
+  val usable = doses.filter { !it.at.isAfter(now) && it.amount.isFinite() && it.amount > 0.0 }
+  val reference = referenceBurden(usable, lambda, tolerance)
+  val current = burdenAt(usable, now, lambda)
+  // Also covers an empty list, whose reference burden is zero.
+  if (!reference.isFinite() || reference <= 0.0 || !current.isFinite()) return null
+
+  val minimumRatio = exp(-lambda * MaxEffectiveAbstinenceDays)
+  val ratio = (current / reference).coerceIn(minimumRatio, 1.0)
+  return (-ln(ratio) / lambda).daysAsDuration()
+}
+
+/**
+ * Burden evaluated at each dose instant, computed as a running recurrence rather than one sum per dose,
+ * so that scanning for the peak stays linear in the number of doses.
+ */
+private fun burdenAtEachDose(ordered: List<Dose>, lambda: Double): DoubleArray {
+  val burdens = DoubleArray(ordered.size)
+  var running = 0.0
+  for (index in ordered.indices) {
+    if (index > 0) running *= exp(-lambda * daysBetween(ordered[index - 1].at, ordered[index].at))
+    running += ordered[index].amount
+    burdens[index] = running
+  }
+  return burdens
+}
+
+private fun daysBetween(from: LocalDateTime, to: LocalDateTime) = SECONDS.between(from, to) / SecondsPerDay
+
+private fun Double.daysAsDuration() = Duration.ofSeconds((this * SecondsPerDay).roundToLong())

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
@@ -7,13 +7,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.viewinterop.AndroidView
 import br.com.colman.petals.withdrawal.interpolator.Interpolator
+import br.com.colman.petals.withdrawal.tolerance.SecondsPerDay
 import com.jjoe64.graphview.GraphView
 import com.jjoe64.graphview.series.DataPoint
 import com.jjoe64.graphview.series.LineGraphSeries
 import com.jjoe64.graphview.series.PointsGraphSeries
 import java.time.Duration
-
-const val SecondsPerDay = 86400
 
 @Composable
 @Suppress("LongParameterList")

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
@@ -12,14 +12,13 @@ import com.jjoe64.graphview.series.DataPoint
 import com.jjoe64.graphview.series.LineGraphSeries
 import com.jjoe64.graphview.series.PointsGraphSeries
 import java.time.Duration
-import java.time.LocalDateTime
-import java.time.LocalDateTime.now
-import java.time.temporal.ChronoUnit.SECONDS
+
+const val SecondsPerDay = 86400
 
 @Composable
 @Suppress("LongParameterList")
 fun WithdrawalChart(
-  lastUseDate: LocalDateTime?,
+  effectiveAbstinence: Duration?,
   data: Map<Duration, Double>,
   graphTitle: Context.(currentValue: Double?) -> String,
   verticalAxisTitle: String,
@@ -33,22 +32,42 @@ fun WithdrawalChart(
   val interpolator = Interpolator(scaledData)
 
   AndroidView({
-    createGraph(it, verticalAxisTitle, horizontalAxisTitle, lastUseDate, colors, scaledData, maxX, maxY)
+    createGraph(it, verticalAxisTitle, horizontalAxisTitle, effectiveAbstinence, colors, scaledData, maxX, maxY)
   }, update = {
-    val currentValue = lastUseDate?.let { lud -> interpolator.value(lud.daysToTodayInSeconds().times(SecondsPerDay)) }
+    val currentValue = effectiveAbstinence?.let { abstinence -> chartPointFor(interpolator, abstinence, maxX).second }
     it.title = graphTitle(it.context, currentValue)
     it.removeAllSeries()
     it.addSeries(scaledData.toLineGraphSeries().apply { color = colors.secondary.toArgb() })
 
-    if (lastUseDate != null) {
-      it.addSeries(interpolator.currentPointSeries(lastUseDate).apply { color = colors.primary.toArgb() })
+    if (effectiveAbstinence != null) {
+      it.addSeries(
+        currentPointSeries(interpolator, effectiveAbstinence, maxX).apply { color = colors.primary.toArgb() }
+      )
     }
     it.invalidate()
   })
 }
 
-private fun Map<Duration, Double>.scaled(maxY: Double): Map<Duration, Double> {
-  return mapValues { ((it.value - values.min()) * maxY / (values.max() - values.min())) }
+/**
+ * Each curve rescaled so its own minimum sits at 0 and its own maximum at [maxY]. The reported number is
+ * therefore relative to the study's range, not an absolute score. A curve with no spread at all collapses
+ * to zero rather than to NaN, which would silently render a blank chart.
+ */
+fun Map<Duration, Double>.scaled(maxY: Double): Map<Duration, Double> {
+  val min = values.min()
+  val max = values.max()
+  if (max == min) return mapValues { 0.0 }
+  return mapValues { ((it.value - min) * maxY / (max - min)) }
+}
+
+/**
+ * Where the "you are here" dot sits: x in days, y interpolated from the curve. The x is clamped into the
+ * chart's visible range, since [maxX] differs per chart and an unclamped dot is simply drawn out of view.
+ * Pure - no Compose, no clock - so it is unit-testable.
+ */
+fun chartPointFor(interpolator: Interpolator, abstinence: Duration, maxX: Double): Pair<Double, Double> {
+  val days = (abstinence.seconds.toDouble() / SecondsPerDay).coerceIn(0.0, maxX)
+  return days to interpolator.value(days * SecondsPerDay)
 }
 
 @Suppress("LongParameterList")
@@ -56,7 +75,7 @@ private fun createGraph(
   context: Context,
   verticalAxisTitle: String,
   horizontalAxisTitle: String,
-  lastUseDate: LocalDateTime?,
+  effectiveAbstinence: Duration?,
   colors: Colors,
   data: Map<Duration, Double>,
   maxX: Double,
@@ -65,7 +84,7 @@ private fun createGraph(
   val interpolator = Interpolator(data)
 
   addSeries(data.toLineGraphSeries())
-  if (lastUseDate != null) addSeries(interpolator.currentPointSeries(lastUseDate))
+  if (effectiveAbstinence != null) addSeries(currentPointSeries(interpolator, effectiveAbstinence, maxX))
 
   viewport.apply {
     isXAxisBoundsManual = true
@@ -98,13 +117,14 @@ private fun Map<Duration, Double>.toLineGraphSeries(): LineGraphSeries<DataPoint
   }
 }
 
-private fun Interpolator.currentPointSeries(lastUseDate: LocalDateTime): PointsGraphSeries<DataPoint> {
-  val daysQuit = lastUseDate.daysToTodayInSeconds()
-  return PointsGraphSeries(arrayOf(DataPoint(daysQuit, value(daysQuit.times(SecondsPerDay))))).apply {
+private fun currentPointSeries(
+  interpolator: Interpolator,
+  abstinence: Duration,
+  maxX: Double
+): PointsGraphSeries<DataPoint> {
+  val (x, y) = chartPointFor(interpolator, abstinence, maxX)
+  return PointsGraphSeries(arrayOf(DataPoint(x, y))).apply {
     size = 15f
     shape = PointsGraphSeries.Shape.POINT
   }
 }
-
-const val SecondsPerDay = 86400
-private fun LocalDateTime.daysToTodayInSeconds() = SECONDS.between(this, now()).toDouble().div(SecondsPerDay)

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/listitem/ToleranceModelEnabledListItem.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/listitem/ToleranceModelEnabledListItem.kt
@@ -1,0 +1,24 @@
+package br.com.colman.petals.withdrawal.view.listitem
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import br.com.colman.petals.R.string.enable_or_disable_tolerance_model
+import br.com.colman.petals.R.string.tolerance_model_enabled
+import br.com.colman.petals.settings.view.dialog.SwitchListItem
+import compose.icons.TablerIcons
+import compose.icons.tablericons.Scale
+
+@Preview
+@Composable
+fun ToleranceModelEnabledListItem(
+  toleranceModelEnabled: Boolean = true,
+  setToleranceModelEnabled: (Boolean) -> Unit = {}
+) {
+  SwitchListItem(
+    icon = TablerIcons.Scale,
+    textId = tolerance_model_enabled,
+    descriptionId = enable_or_disable_tolerance_model,
+    initialState = toleranceModelEnabled,
+    onChangeState = setToleranceModelEnabled
+  )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,11 @@
     <string name="status">Status</string>
     <string name="stats">Stats</string>
     <string name="drug_test">Drug Test</string>
-    <string name="symptoms_introduction">A study from Budney et al. from the University of Vermont established how withdrawal symptoms affect and decay on cannabis users. Below you\'ll see an estimate of your current situation based on your last use date.</string>
+    <string name="symptoms_introduction">A study from Budney et al. from the University of Vermont established how withdrawal symptoms affect and decay on cannabis users. Below you\'ll see an estimate of your current situation. Because tolerance builds up over time, this estimate is based on how much you\'ve been using recently compared to your regular habit, not only on your last use date.</string>
+    <string name="effective_abstinence_explained">Your body is where a regular user would be %1$s after quitting. Your last use was %2$s ago.</string>
+    <string name="effective_abstinence_sessions_mode">Estimated from how often you log, because most of your entries don\'t record an amount.</string>
+    <string name="effective_abstinence_unavailable">Not enough history yet, so this shows the time since your last use.</string>
+    <string name="effective_abstinence_disabled">Tolerance adjustment is off, so this shows the time since your last use.</string>
     <string name="hit_timer">Hit Timer</string>
     <string name="start">Start</string>
     <string name="reset">Reset</string>
@@ -137,6 +141,8 @@
     <string name="enable_or_disable_hour_of_day_line_in_stats">Enable or disable hour of day line on the graphs</string>
     <string name="break_period_in_stats_enabled">Toggle Break Periods</string>
     <string name="enable_or_disable_break_period_in_stats">Enable or disable break periods on the hourly graph</string>
+    <string name="tolerance_model_enabled">Account for tolerance in withdrawal</string>
+    <string name="enable_or_disable_tolerance_model">Estimate withdrawal from your recent intake compared to your regular habit, instead of only your last use date</string>
     <string name="wait_until_3am_to_show_a_new_day">Wait until 3:00 AM to show a new day. Useful if you typically go to sleep after midnight.</string>
     <string name="custom">Custom</string>
     <string name="general_knowledge">General Knowledge</string>

--- a/app/src/main/sqldelight/br/com/colman/petals/Use.sq
+++ b/app/src/main/sqldelight/br/com/colman/petals/Use.sq
@@ -21,6 +21,11 @@ SELECT * FROM Use WHERE datetime(date) <= datetime('now', 'localtime') ORDER BY 
 selectAll:
 SELECT * FROM Use;
 
+selectSince:
+SELECT * FROM Use
+WHERE datetime(date) >= datetime(:from) AND datetime(date) <= datetime('now', 'localtime')
+ORDER BY date ASC;
+
 delete:
 DELETE FROM Use WHERE id IS (?);
 

--- a/app/src/test/kotlin/br/com/colman/petals/settings/SettingsRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/settings/SettingsRepositoryTest.kt
@@ -9,6 +9,7 @@ import br.com.colman.petals.settings.SettingsRepository.Companion.IsDarkModeOn
 import br.com.colman.petals.settings.SettingsRepository.Companion.IsDayExtended
 import br.com.colman.petals.settings.SettingsRepository.Companion.IsHitTimerMillisecondsEnabled
 import br.com.colman.petals.settings.SettingsRepository.Companion.IsHourOfDayLineInStatsEnabled
+import br.com.colman.petals.settings.SettingsRepository.Companion.IsToleranceModelEnabled
 import br.com.colman.petals.settings.SettingsRepository.Companion.Pin
 import br.com.colman.petals.settings.SettingsRepository.Companion.TimeFormat
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -160,6 +161,20 @@ class SettingsRepositoryTest : FunSpec({
   test("Persists hour of day line setting") {
     target.setIsHourOfDayLineInStatsEnabled(true)
     datastore.data.first()[IsHourOfDayLineInStatsEnabled] shouldBe true
+  }
+
+  test("Defaults tolerance model to true") {
+    target.isToleranceModelEnabled.first() shouldBe true
+  }
+
+  test("Changes tolerance model to false") {
+    target.setIsToleranceModelEnabled(false)
+    target.isToleranceModelEnabled.first() shouldBe false
+  }
+
+  test("Persists tolerance model setting") {
+    target.setIsToleranceModelEnabled(false)
+    datastore.data.first()[IsToleranceModelEnabled] shouldBe false
   }
 
   test("Pin defaults to null") {

--- a/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
@@ -109,6 +109,40 @@ class UseRepositoryTest : FunSpec({
     target.getLastUseDate().first() shouldBe null
   }
 
+  test("Since returns the window, oldest first") {
+    val old = use.copy(date = use.date.minusDays(10), id = "old")
+    val middle = use.copy(date = use.date.minusDays(5), id = "middle")
+    val recent = use.copy(date = use.date.minusDays(1), id = "recent")
+    target.upsertAll(listOf(recent, old, middle))
+
+    target.since(use.date.minusDays(7)).first() shouldBe listOf(middle, recent)
+  }
+
+  test("Since includes a use sitting exactly on the cutoff") {
+    val boundary = use.copy(date = use.date.minusDays(5), id = "boundary")
+    target.upsert(boundary)
+
+    target.since(boundary.date).first() shouldBe listOf(boundary)
+  }
+
+  test("Since should disconsider uses in the future") {
+    val useInTheFuture = use.copy(date = use.date.plusHours(3), id = "2")
+    target.upsert(use)
+    target.upsert(useInTheFuture)
+
+    target.since(use.date.minusDays(1)).first() shouldBe listOf(use)
+  }
+
+  test("Since performance") {
+    UseArb.take(10_000).map(Use::toEntity).forEach(database.useQueries::upsert)
+
+    measureTimeMillis {
+      target.since(use.date.minusDays(90)).first()
+    } shouldBeLessThan measureTimeMillis {
+      target.all().first().filter { it.date >= use.date.minusDays(90) }
+    }
+  }
+
   test("Last use performance") {
     UseArb.take(10_000).map(Use::toEntity).forEach(database.useQueries::upsert)
 

--- a/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
@@ -133,14 +133,11 @@ class UseRepositoryTest : FunSpec({
     target.since(use.date.minusDays(1)).first() shouldBe listOf(use)
   }
 
-  test("Since performance") {
+  test("Since returns the same window as filtering all") {
     UseArb.take(10_000).map(Use::toEntity).forEach(database.useQueries::upsert)
 
-    measureTimeMillis {
-      target.since(use.date.minusDays(90)).first()
-    } shouldBeLessThan measureTimeMillis {
-      target.all().first().filter { it.date >= use.date.minusDays(90) }
-    }
+    val from = use.date.minusDays(90)
+    target.since(from).first() shouldBe target.all().first().filter { it.date >= from }.sortedBy { it.date }
   }
 
   test("Last use performance") {

--- a/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
@@ -134,10 +134,15 @@ class UseRepositoryTest : FunSpec({
   }
 
   test("Since returns the same window as filtering all") {
-    UseArb.take(10_000).map(Use::toEntity).forEach(database.useQueries::upsert)
+    val history = (1..200).map { use.copy(date = use.date.minusDays(it.toLong()), id = "$it") }
+    val future = use.copy(date = use.date.plusDays(3), id = "future")
+    target.upsertAll(history + future)
 
     val from = use.date.minusDays(90)
-    target.since(from).first() shouldBe target.all().first().filter { it.date >= from }.sortedBy { it.date }
+    // The same two bounds selectSince applies: at or after the cutoff, and not in the future.
+    val expected = (history + future).filter { it.date >= from && it.date <= use.date }.sortedBy { it.date }
+
+    target.since(from).first() shouldBe expected
   }
 
   test("Last use performance") {

--- a/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/repository/UseRepositoryTest.kt
@@ -125,7 +125,7 @@ class UseRepositoryTest : FunSpec({
     target.since(boundary.date).first() shouldBe listOf(boundary)
   }
 
-  test("Since should disconsider uses in the future") {
+  test("Since should disregard uses in the future") {
     val useInTheFuture = use.copy(date = use.date.plusHours(3), id = "2")
     target.upsert(use)
     target.upsert(useInTheFuture)

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/interpolator/InterpolatorTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/interpolator/InterpolatorTest.kt
@@ -19,6 +19,18 @@ class InterpolatorTest : FunSpec({
     target.value(100.0) shouldBe 20.0
   }
 
+  test("Should respect minPossibleX") {
+    val data = mapOf(
+      seconds(10) to 20.0,
+      seconds(20) to 40.0
+    )
+    val target = Interpolator(data)
+
+    target.value(10.0) shouldBe 20.0
+    target.value(0.0) shouldBe 20.0
+    target.value(-100.0) shouldBe 20.0
+  }
+
   test("should implement UnivariateFunction") {
     val data = mapOf(
       seconds(0) to 0.0,

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeriesTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeriesTest.kt
@@ -1,0 +1,136 @@
+package br.com.colman.petals.withdrawal.tolerance
+
+import br.com.colman.petals.use.UseArb
+import br.com.colman.petals.use.repository.Use
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Disabled
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Grams
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.LastUseOnly
+import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Sessions
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.LocalDateTime
+
+private val Now: LocalDateTime = LocalDateTime.of(2026, 1, 1, 12, 0)
+
+private fun Duration.inDays() = seconds.toDouble() / 86_400.0
+
+private fun use(daysAgo: Double, grams: Double) =
+  Use(Now.minusSeconds((daysAgo * 86_400).toLong()), BigDecimal(grams.toString()))
+
+private fun uses(days: Int, perDay: Int, grams: Double, endingDaysAgo: Double = 0.0): List<Use> {
+  val total = days * perDay
+  return (0 until total).map { use(endingDaysAgo + (total - 1 - it).toDouble() / perDay, grams) }
+}
+
+private fun estimate(uses: List<Use>, modelEnabled: Boolean = true) =
+  estimateAbstinence(uses, uses.maxByOrNull { it.date }?.date, Now, modelEnabled)
+
+class DoseSeriesTest : FunSpec({
+
+  test("No use at all means no estimate") {
+    estimateAbstinence(emptyList(), null, Now, true).shouldBeNull()
+  }
+
+  test("With the model switched off the reading is the time since the last use") {
+    val history = uses(days = 90, perDay = 1, grams = 28.0, endingDaysAgo = 14.0) + uses(14, 1, 3.5)
+
+    val result = estimate(history, modelEnabled = false)!!
+
+    // Not LastUseOnly: the user has plenty of history, they just turned the adjustment off, and the
+    // screen tells them so rather than claiming there is not enough data.
+    result.mode shouldBe Disabled
+    result.effective shouldBe result.actual
+  }
+
+  test("Fewer uses than the minimum falls back to the time since the last use") {
+    val result = estimate(listOf(use(5.0, 3.0), use(4.0, 3.0)))!!
+
+    result.mode shouldBe LastUseOnly
+    result.effective.inDays() shouldBe (4.0 plusOrMinus 1e-4)
+  }
+
+  test("An ounce a day cut to an eighth reads as mid withdrawal while the last use was minutes ago") {
+    val history = uses(days = 90, perDay = 1, grams = 28.0, endingDaysAgo = 14.0) + uses(14, 1, 3.5)
+
+    val result = estimate(history)!!
+
+    result.mode shouldBe Grams
+    result.actual.inDays() shouldBe (0.0 plusOrMinus 1e-4)
+    result.effective.inDays() shouldBeGreaterThan 5.0
+  }
+
+  test("Amounts are trusted at exactly the coverage threshold and not below it") {
+    // A hundred uses spread over fifty days, so the whole set sits inside the lookback window.
+    fun window(positives: Int) = (0 until 100).map { index ->
+      use(daysAgo = 0.5 + index * 0.5, grams = if (index < positives) 2.0 else 0.0)
+    }
+
+    estimate(window(80))!!.mode shouldBe Grams
+    estimate(window(79))!!.mode shouldBe Sessions
+  }
+
+  test("A history with no amounts at all still detects a reduction, counting sessions") {
+    val heavy = uses(days = 60, perDay = 8, grams = 0.0, endingDaysAgo = 14.0)
+    val reduced = uses(days = 14, perDay = 1, grams = 0.0)
+
+    val result = estimate(heavy + reduced)!!
+
+    result.mode shouldBe Sessions
+    result.effective.inDays() shouldBeGreaterThan 4.0
+  }
+
+  test("Absurd amounts are capped so a single typo cannot pin the reading") {
+    val typo = uses(days = 30, perDay = 1, grams = 2.0, endingDaysAgo = 3.0) + listOf(use(31.0, 280.0))
+    val capped = uses(days = 30, perDay = 1, grams = 2.0, endingDaysAgo = 3.0) + listOf(use(31.0, 100.0))
+
+    estimate(typo)!!.effective shouldBe estimate(capped)!!.effective
+  }
+
+  test("Negative amounts do not count as doses") {
+    val history = uses(days = 30, perDay = 1, grams = 2.0, endingDaysAgo = 2.0)
+
+    estimate(history + listOf(use(1.0, -50.0)))!!.effective shouldBe estimate(history)!!.effective
+  }
+
+  test("Uses older than the lookback window are not read") {
+    val recent = uses(days = 10, perDay = 1, grams = 2.0, endingDaysAgo = 1.0)
+    val ancient = uses(days = 10, perDay = 1, grams = 40.0, endingDaysAgo = 200.0)
+
+    estimate(recent + ancient)!!.effective shouldBe estimate(recent)!!.effective
+  }
+
+  test("Future dated uses never shorten or lengthen the reading") {
+    val history = uses(days = 30, perDay = 1, grams = 3.0, endingDaysAgo = 2.0)
+    val future = listOf(Use(Now.plusDays(5), BigDecimal("3.0")))
+
+    val withFuture = estimateAbstinence(history + future, history.last().date, Now, true)!!
+
+    withFuture.effective shouldBe estimate(history)!!.effective
+  }
+
+  test("Any history at all produces a sane reading") {
+    checkAll(Arb.list(UseArb, 0..60)) { generated ->
+      val result = estimateAbstinence(generated, generated.maxByOrNull { it.date }?.date, Now, true)
+
+      if (result != null) {
+        result.effective.isNegative shouldBe false
+        result.actual.isNegative shouldBe false
+        // The cap belongs to the model. The fallback is the literal elapsed time, which has no ceiling.
+        if (result.mode != LastUseOnly) {
+          result.effective.inDays() shouldBeLessThanOrEqual MaxEffectiveAbstinenceDays
+        } else {
+          result.effective shouldBe result.actual
+        }
+      }
+    }
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeriesTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeriesTest.kt
@@ -7,6 +7,7 @@ import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Grams
 import br.com.colman.petals.withdrawal.tolerance.EstimateMode.LastUseOnly
 import br.com.colman.petals.withdrawal.tolerance.EstimateMode.Sessions
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThanOrEqual
@@ -21,10 +22,10 @@ import java.time.LocalDateTime
 
 private val Now: LocalDateTime = LocalDateTime.of(2026, 1, 1, 12, 0)
 
-private fun Duration.inDays() = seconds.toDouble() / 86_400.0
+private fun Duration.inDays() = seconds.toDouble() / SecondsPerDay
 
 private fun use(daysAgo: Double, grams: Double) =
-  Use(Now.minusSeconds((daysAgo * 86_400).toLong()), BigDecimal(grams.toString()))
+  Use(Now.minusSeconds((daysAgo * SecondsPerDay).toLong()), BigDecimal(grams.toString()))
 
 private fun uses(days: Int, perDay: Int, grams: Double, endingDaysAgo: Double = 0.0): List<Use> {
   val total = days * perDay
@@ -88,11 +89,13 @@ class DoseSeriesTest : FunSpec({
     result.effective.inDays() shouldBeGreaterThan 4.0
   }
 
-  test("Absurd amounts are capped so a single typo cannot pin the reading") {
-    val typo = uses(days = 30, perDay = 1, grams = 2.0, endingDaysAgo = 3.0) + listOf(use(31.0, 280.0))
-    val capped = uses(days = 30, perDay = 1, grams = 2.0, endingDaysAgo = 3.0) + listOf(use(31.0, 100.0))
+  test("Large amounts are taken at face value rather than capped") {
+    val history = uses(days = 30, perDay = 1, grams = 2.0, endingDaysAgo = 3.0)
+    val hugePeak = history + listOf(use(31.0, 280.0))
+    val smallerPeak = history + listOf(use(31.0, 100.0))
 
-    estimate(typo)!!.effective shouldBe estimate(capped)!!.effective
+    // A bigger past peak puts today's intake further below it, so the reading has to be longer.
+    estimate(hugePeak)!!.effective shouldBeGreaterThan estimate(smallerPeak)!!.effective
   }
 
   test("Negative amounts do not count as doses") {

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurdenTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurdenTest.kt
@@ -13,14 +13,14 @@ import kotlin.math.ln
 
 private val Now: LocalDateTime = LocalDateTime.of(2026, 1, 1, 12, 0)
 
-private fun Duration.inDays() = seconds.toDouble() / 86_400.0
+private fun Duration.inDays() = seconds.toDouble() / SecondsPerDay
 
 /** [days] of [perDay] doses of [each] grams, ending [endingDaysAgo] days before [Now]. */
 private fun history(days: Int, perDay: Int, each: Double, endingDaysAgo: Double = 0.0): List<Dose> {
   val total = days * perDay
   return (0 until total).map { index ->
     val daysAgo = endingDaysAgo + (total - 1 - index).toDouble() / perDay
-    Dose(Now.minusSeconds((daysAgo * 86_400).toLong()), each)
+    Dose(Now.minusSeconds((daysAgo * SecondsPerDay).toLong()), each)
   }
 }
 

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurdenTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcBurdenTest.kt
@@ -1,0 +1,149 @@
+package br.com.colman.petals.withdrawal.tolerance
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.Duration
+import java.time.LocalDateTime
+import kotlin.math.ln
+
+private val Now: LocalDateTime = LocalDateTime.of(2026, 1, 1, 12, 0)
+
+private fun Duration.inDays() = seconds.toDouble() / 86_400.0
+
+/** [days] of [perDay] doses of [each] grams, ending [endingDaysAgo] days before [Now]. */
+private fun history(days: Int, perDay: Int, each: Double, endingDaysAgo: Double = 0.0): List<Dose> {
+  val total = days * perDay
+  return (0 until total).map { index ->
+    val daysAgo = endingDaysAgo + (total - 1 - index).toDouble() / perDay
+    Dose(Now.minusSeconds((daysAgo * 86_400).toLong()), each)
+  }
+}
+
+private fun daysQuit(doses: List<Dose>) = effectiveAbstinence(doses, Now)!!.inDays()
+
+class ThcBurdenTest : FunSpec({
+
+  test("A clean quitter reads exactly the time since their last use") {
+    listOf(0.0, 1.0, 5.0, 12.5, 20.0, 26.0).forEach { quitDaysAgo ->
+      daysQuit(history(days = 90, perDay = 4, each = 7.0, endingDaysAgo = quitDaysAgo)) shouldBe
+        (quitDaysAgo plusOrMinus 1e-4)
+    }
+  }
+
+  test("Dosing cadence does not shift a clean quitter") {
+    val once = daysQuit(history(days = 90, perDay = 1, each = 28.0, endingDaysAgo = 6.0))
+    val eight = daysQuit(history(days = 90, perDay = 8, each = 3.5, endingDaysAgo = 6.0))
+
+    once shouldBe (6.0 plusOrMinus 1e-4)
+    eight shouldBe (6.0 plusOrMinus 1e-4)
+  }
+
+  test("Lambda does not affect a clean quitter") {
+    val doses = history(days = 90, perDay = 2, each = 14.0, endingDaysAgo = 9.0)
+
+    listOf(0.10, 0.15, 0.26).forEach { lambda ->
+      effectiveAbstinence(doses, Now, lambda)!!.inDays() shouldBe (9.0 plusOrMinus 1e-4)
+    }
+  }
+
+  test("An ounce a day cut to an eighth reads as mid withdrawal, not day zero") {
+    val heavy = history(days = 90, perDay = 1, each = 28.0, endingDaysAgo = 14.0)
+    val reduced = history(days = 14, perDay = 1, each = 3.5)
+
+    // The app used to read the time since the last use, which here is under a day.
+    daysQuit(heavy + reduced) shouldBe (6.9 plusOrMinus 0.5)
+  }
+
+  test("A sustained reduction fades as tolerance readjusts") {
+    val heavy = history(days = 90, perDay = 1, each = 28.0, endingDaysAgo = 60.0)
+    val reduced = history(days = 60, perDay = 1, each = 3.5)
+
+    daysQuit(heavy + reduced) shouldBeLessThan 1.0
+  }
+
+  test("An old binge does not flag a stable user") {
+    val steady = history(days = 150, perDay = 1, each = 2.0)
+    val binge = history(days = 7, perDay = 1, each = 20.0, endingDaysAgo = 80.0)
+
+    daysQuit(steady + binge) shouldBe (0.0 plusOrMinus 0.01)
+  }
+
+  test("Holding a k-fold reduction settles at ln(k)/lambda before tolerance releases it") {
+    val heavy = history(days = 90, perDay = 1, each = 28.0, endingDaysAgo = 30.0)
+    val reduced = history(days = 30, perDay = 1, each = 3.5)
+
+    val withoutRelease = effectiveAbstinence(heavy + reduced, Now, tolerance = 0.0)!!.inDays()
+
+    withoutRelease shouldBe (ln(8.0) / ThcEliminationPerDay plusOrMinus 0.6)
+  }
+
+  test("Using at the all time peak reads as no withdrawal at all") {
+    val ramping = history(days = 30, perDay = 1, each = 2.0) + history(days = 1, perDay = 1, each = 50.0)
+
+    daysQuit(ramping) shouldBe (0.0 plusOrMinus 1e-6)
+  }
+
+  test("Future dated doses are ignored rather than blowing the burden up") {
+    val past = history(days = 30, perDay = 1, each = 3.0, endingDaysAgo = 4.0)
+    val future = listOf(Dose(Now.plusDays(30), 3.0))
+
+    daysQuit(past + future) shouldBe (daysQuit(past) plusOrMinus 1e-6)
+  }
+
+  test("A single lifetime use reads as the time since it happened") {
+    daysQuit(listOf(Dose(Now.minusDays(3), 1.0))) shouldBe (3.0 plusOrMinus 1e-4)
+  }
+
+  test("The reading is never negative and never exceeds the cap") {
+    val ancient = listOf(Dose(Now.minusDays(365), 40.0), Dose(Now.minusDays(364), 40.0))
+
+    val days = daysQuit(ancient)
+    days shouldBeGreaterThan 0.0
+    days shouldBe (MaxEffectiveAbstinenceDays plusOrMinus 1e-6)
+  }
+
+  test("No usable dose means no estimate") {
+    effectiveAbstinence(emptyList(), Now).shouldBeNull()
+    effectiveAbstinence(listOf(Dose(Now.minusDays(1), 0.0)), Now).shouldBeNull()
+    effectiveAbstinence(listOf(Dose(Now.minusDays(1), -5.0)), Now).shouldBeNull()
+    effectiveAbstinence(listOf(Dose(Now.plusDays(1), 5.0)), Now).shouldBeNull()
+  }
+
+  test("Burden decays between doses and jumps on each one") {
+    val doses = listOf(Dose(Now.minusDays(2), 10.0))
+
+    burdenAt(doses, Now.minusDays(3)) shouldBe 0.0
+    burdenAt(doses, Now.minusDays(2)) shouldBe (10.0 plusOrMinus 1e-9)
+    burdenAt(doses, Now.minusDays(1)) shouldBeLessThan 10.0
+    burdenAt(doses, Now) shouldBeLessThan burdenAt(doses, Now.minusDays(1))
+  }
+
+  test("The running recurrence used to find the peak agrees with the direct sum") {
+    val doses = history(days = 20, perDay = 3, each = 1.5)
+    val direct = doses.maxOf { burdenAt(doses, it.at) }
+
+    referenceBurden(doses, tolerance = 0.0) shouldBe (direct plusOrMinus 1e-9)
+  }
+
+  test("Adding a dose can only lower the reading") {
+    val doses = history(days = 40, perDay = 2, each = 3.0, endingDaysAgo = 5.0)
+    val extra = Dose(Now.minusDays(1), 3.0)
+
+    daysQuit(doses + extra) shouldBeLessThan daysQuit(doses)
+  }
+
+  test("With a frozen history the reading only grows as time passes") {
+    val doses = history(days = 40, perDay = 2, each = 3.0, endingDaysAgo = 2.0)
+
+    val today = effectiveAbstinence(doses, Now)!!
+    val tomorrow = effectiveAbstinence(doses, Now.plusDays(1))!!
+
+    (tomorrow > today) shouldBe true
+    tomorrow shouldNotBe today
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcDecayConstantTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/ThcDecayConstantTest.kt
@@ -1,0 +1,37 @@
+package br.com.colman.petals.withdrawal.tolerance
+
+import br.com.colman.petals.withdrawal.data.ThcConcentrationDataPoints
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import kotlin.math.ln
+
+/**
+ * Pins [ThcEliminationPerDay] to the data the app already ships, so nobody can quietly replace it with a
+ * rounder number. Fitting a shorter range gives a materially different constant (truncating at day 7 gives
+ * a 3.0 day half-life instead of 4.6), and the constant sets how strongly a reduction registers.
+ */
+class ThcDecayConstantTest : FunSpec({
+
+  val positivePoints = ThcConcentrationDataPoints.filterValues { it > 0.0 }
+
+  test("Lambda is the log-linear fit of the shipped THC curve") {
+    val xs = positivePoints.keys.map { it.toDays().toDouble() }
+    val ys = positivePoints.values.map { ln(it) }
+    val meanX = xs.average()
+    val meanY = ys.average()
+
+    val slope = xs.zip(ys).sumOf { (x, y) -> (x - meanX) * (y - meanY) } / xs.sumOf { (it - meanX) * (it - meanX) }
+
+    -slope shouldBe (ThcEliminationPerDay plusOrMinus 1e-9)
+  }
+
+  test("Half life is four and a half days") {
+    ln(2.0) / ThcEliminationPerDay shouldBe (4.594 plusOrMinus 0.001)
+  }
+
+  test("The fit excludes exactly one point, the day twenty zero, since ln(0) is undefined") {
+    positivePoints.size shouldBe ThcConcentrationDataPoints.size - 1
+    ThcConcentrationDataPoints.values.count { it <= 0.0 } shouldBe 1
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChartMathTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChartMathTest.kt
@@ -1,0 +1,54 @@
+package br.com.colman.petals.withdrawal.view
+
+import br.com.colman.petals.withdrawal.interpolator.Interpolator
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+
+class WithdrawalChartMathTest : FunSpec({
+
+  val curve = mapOf(Duration.ofDays(0) to 3.5, Duration.ofDays(2) to 7.5, Duration.ofDays(25) to 3.0)
+
+  test("Scaling puts the curve minimum at zero and its maximum at the ceiling") {
+    val scaled = curve.scaled(10.0)
+
+    scaled[Duration.ofDays(25)] shouldBe (0.0 plusOrMinus 1e-9)
+    scaled[Duration.ofDays(2)] shouldBe (10.0 plusOrMinus 1e-9)
+    scaled[Duration.ofDays(0)] shouldBe (1.111 plusOrMinus 0.001)
+  }
+
+  test("A curve with no spread collapses to zero instead of NaN") {
+    val flat = mapOf(Duration.ofDays(0) to 4.0, Duration.ofDays(5) to 4.0)
+
+    flat.scaled(10.0).values.forEach { it shouldBe 0.0 }
+  }
+
+  test("The current point sits at the abstinence time, in days") {
+    val interpolator = Interpolator(curve.scaled(10.0))
+
+    val (x, y) = chartPointFor(interpolator, Duration.ofDays(2), 25.0)
+
+    x shouldBe (2.0 plusOrMinus 1e-9)
+    y shouldBe (10.0 plusOrMinus 1e-9)
+  }
+
+  test("Half days are not truncated away") {
+    val interpolator = Interpolator(curve.scaled(10.0))
+
+    chartPointFor(interpolator, Duration.ofHours(12), 25.0).first shouldBe (0.5 plusOrMinus 1e-9)
+  }
+
+  test("A reading past the chart edge is pulled back into view") {
+    val interpolator = Interpolator(curve.scaled(10.0))
+
+    chartPointFor(interpolator, Duration.ofDays(40), 20.0).first shouldBe 20.0
+    chartPointFor(interpolator, Duration.ofDays(40), 25.0).first shouldBe 25.0
+  }
+
+  test("A negative reading is pulled back to zero") {
+    val interpolator = Interpolator(curve.scaled(10.0))
+
+    chartPointFor(interpolator, Duration.ofDays(-5), 25.0).first shouldBe 0.0
+  }
+})


### PR DESCRIPTION
## Why

From a store review:

> Unfortunately, it seems to base the timing strictly on "last smoke", and not the overall intake. Meaning, if I consume an ounce a day regularly, but switch down to 1/8th for a day, the app still registers my withdrawal symptoms as "just starting", even though this is clearly not the case.

They're right. `SymptomsPage` collected `getLastUseDate()` and nothing else, so `amountGrams` never reached the withdrawal package and any use of any size reset all eight curves to day zero.

## What

The curves are now read at an **effective abstinence** derived from the intake history:

```
C(t)   = Σ aᵢ · e^(−λ(t − tᵢ))                            body burden
C_ref  = max over doses of C(tᵢ) · e^(−λ_tol(t_last − tᵢ))  peak reached, slowly released
t_eff  = −ln( C(now) / C_ref ) / λ
```

**Why the peak reached, and not a baseline g/day ÷ λ.** Discrete dosing makes a steady user's burden a sawtooth peaking above `B/λ`, so the baseline formulation puts a once-daily clean quitter **0.49 days behind the old app, permanently**. Against the peak it cancels: `t_eff` equals time-since-last-use for every cadence and every λ. That's the load-bearing test.

**Why the slow release.** Without it a sustained 8× cut reads `ln(8)/λ = 13.8 d` forever and then cliffs to 0 when the heavy period leaves the window, and one binge week 40 days ago flags a stable user at 13.1 days. Released from the last dose (so it cancels for a clean quitter), those glide to 0.4 and fade to 0.

λ = **0.150865/day** (t½ 4.59 d), fitted from `ThcConcentrationDataPoints` — data the app already ships — with the fit reproduced in a test so it can't drift to a rounder number. Fitting only days 0–7 would give 3.0 d, and λ sets the whole scale, so this is pinned deliberately.

**Degradation**: grams → sessions (`aᵢ = 1`, so 8 sessions/day → 1 registers the same reduction; `AddUseButton` writes 0 g for a blank field, so amount-less histories are common) → plain last-use. A settings toggle, default on, reverts to the old behaviour.

## Also fixed

Three latent bugs this made reachable:
- `Interpolator` threw `OutOfRangeException` below its first knot (unreachable before only because `selectLast` filters future dates)
- the "you are here" dot was drawn outside the viewport for readings past `maxX`, i.e. invisible
- `scaled()` returned `NaN` on a flat curve, silently blanking the chart

`daysToTodayInSeconds()` is gone, so the chart layer has no clock and is now unit-tested.

## Testing

41 new tests. No schema migration (new `SELECT` only). Detekt clean, Kover 98% on `withdrawal/tolerance`.

Verified on a Pixel_9a emulator with seeded histories:

| Scenario | Reading |
|---|---|
| 90d @ 28g/d → 14d @ 3.5g/d, last use 2h ago | **6.7 d** effective vs **0.1 d** actual |
| 90d @ 4×/day then stopped 5 days ago | **5.0 = 5.0**, unchanged from today |
| Same reduction, zero grams recorded | **6.5 d**, sessions mode |
| Two uses total | falls back to time since last use |
| Empty database | no dot, no crash |
| Toggle off | 97.50% THC, dot at day 0.1 — old behaviour |

## Follow-ups, not in this PR

- `DrugTestPage` still uses raw `lastUseDate` for detection windows, which are far more tolerance-dependent than symptoms. `C_ref` is directly reusable there.
- Chart titles report min-max **rescaled** values, so "discomfort: 10.00" means "at the study's peak", not 10/10. `t_eff` lands users near peaks more often, making the misreading more common.
- `λ_tol` (t½ 21 d) is a tuning constant, not a measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZhzG934mSYQb7hsQweWkk