### PR TITLE
✨ Show where the current hit sits on the breathhold curves

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
@@ -107,9 +107,16 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
         Text(stringResource(vibrate_on_timer_end))
       }
     }
-    WhyTenSeconds()
+    WhyTenSeconds(holdSecondsOf(millisLeft, hitTimer.durationMillis))
   }
 }
+
+/**
+ * How long the current hit has been held, in seconds: the timer counts down, the curves are drawn
+ * against time held, so the marker needs the elapsed side of it.
+ */
+fun holdSecondsOf(millisLeft: Long, durationMillis: Long): Double =
+  ((durationMillis - millisLeft).coerceAtLeast(0) / 1000.0)
 
 @Composable
 private fun TimerText(millisLeft: Long) {

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
@@ -58,12 +58,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.getSystemService
 import br.com.colman.petals.R.color.smokeColor
+import br.com.colman.petals.R.string.holding_past_peak
 import br.com.colman.petals.R.string.reset
 import br.com.colman.petals.R.string.start
 import br.com.colman.petals.R.string.vibrate_on_timer_end
 import br.com.colman.petals.settings.SettingsRepository
 import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
+import java.util.Locale
 
 @Preview
 @Composable
@@ -71,14 +73,18 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
   val hitTimer = rememberSaveable { HitTimer() }
 
   val ctx = LocalContext.current
-  val millisLeft by hitTimer.millisLeft.collectAsState(hitTimer.durationMillis)
+  val millisElapsed by hitTimer.millisElapsed.collectAsState(0L)
   val shouldVibrate by repository.shouldVibrate.collectAsState(false)
 
+  val millisLeft = (hitTimer.durationMillis - millisElapsed).coerceAtLeast(0)
   val alpha = millisLeft.toFloat() / hitTimer.durationMillis
   val backgroundColor = colorResource(smokeColor).copy(1 - alpha)
 
-  if (millisLeft == 0L && shouldVibrate) {
-    ctx.vibrate()
+  // Keyed on the crossing rather than checked inline: the elapsed counter keeps ticking past the
+  // target, so an inline check would recompose and buzz every hundred milliseconds, forever.
+  val hasReachedTarget = millisLeft == 0L
+  LaunchedEffect(hasReachedTarget, shouldVibrate) {
+    if (hasReachedTarget && shouldVibrate) ctx.vibrate()
   }
 
   Column(
@@ -92,6 +98,8 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
     Box(Modifier.padding(top = 60.dp)) {
       TimerText(millisLeft)
     }
+
+    HoldOvertime(millisElapsed, hitTimer.durationMillis)
 
     Column(Modifier.width(180.dp), spacedBy(8.dp)) {
       Button(onClick = { hitTimer.start() }, Modifier.fillMaxWidth()) {
@@ -107,16 +115,24 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
         Text(stringResource(vibrate_on_timer_end))
       }
     }
-    WhyTenSeconds(holdSecondsOf(millisLeft, hitTimer.durationMillis))
+    WhyTenSeconds(millisElapsed / 1000.0)
   }
 }
 
 /**
- * How long the current hit has been held, in seconds: the timer counts down, the curves are drawn
- * against time held, so the marker needs the elapsed side of it.
+ * Only appears once the target is passed. Until then the countdown already tells you the hold; after
+ * it, this is the only place the real hold time exists, and seeing it is the whole point.
  */
-fun holdSecondsOf(millisLeft: Long, durationMillis: Long): Double =
-  ((durationMillis - millisLeft).coerceAtLeast(0) / 1000.0)
+@Composable
+private fun HoldOvertime(millisElapsed: Long, durationMillis: Long) {
+  if (millisElapsed <= durationMillis) return
+
+  Text(
+    stringResource(holding_past_peak, "%.1f".format(Locale.US, millisElapsed / 1000.0)),
+    fontSize = 20.sp,
+    color = MaterialTheme.colors.error
+  )
+}
 
 @Composable
 private fun TimerText(millisLeft: Long) {

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
@@ -59,7 +59,9 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.getSystemService
 import br.com.colman.petals.R.color.smokeColor
 import br.com.colman.petals.R.string.holding_past_peak
+import br.com.colman.petals.R.string.pause
 import br.com.colman.petals.R.string.reset
+import br.com.colman.petals.R.string.resume
 import br.com.colman.petals.R.string.start
 import br.com.colman.petals.R.string.vibrate_on_timer_end
 import br.com.colman.petals.settings.SettingsRepository
@@ -71,6 +73,8 @@ import java.util.Locale
 @Composable
 fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
   val hitTimer = rememberSaveable { HitTimer() }
+  // While paused the elapsed value stops changing, so nothing recomposes: the label needs its own state.
+  var isPaused by rememberSaveable { mutableStateOf(false) }
 
   val ctx = LocalContext.current
   val millisElapsed by hitTimer.millisElapsed.collectAsState(0L)
@@ -102,13 +106,7 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
     HoldOvertime(millisElapsed, hitTimer.durationMillis)
 
     Column(Modifier.width(180.dp), spacedBy(8.dp)) {
-      Button(onClick = { hitTimer.start() }, Modifier.fillMaxWidth()) {
-        Text(stringResource(start), fontSize = 24.sp)
-      }
-
-      Button(onClick = { hitTimer.reset() }, Modifier.fillMaxWidth()) {
-        Text(stringResource(reset), fontSize = 24.sp)
-      }
+      TimerButtons(hitTimer, millisElapsed, isPaused) { isPaused = it }
 
       Row(Modifier.fillMaxWidth(), Start, CenterVertically) {
         Checkbox(shouldVibrate, { repository.setShouldVibrate(it) })
@@ -116,6 +114,50 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
       }
     }
     WhyTenSeconds(millisElapsed / 1000.0)
+  }
+}
+
+/**
+ * Pause is what makes an unbounded elapsed counter usable: it freezes the reading so you can look at
+ * it, where [HitTimer.reset] would wipe the very number you wanted. Disabled until there is something
+ * to freeze.
+ */
+@Composable
+private fun TimerButtons(
+  hitTimer: HitTimer,
+  millisElapsed: Long,
+  isPaused: Boolean,
+  onPausedChange: (Boolean) -> Unit
+) {
+  Button(
+    onClick = {
+      hitTimer.start()
+      onPausedChange(false)
+    },
+    Modifier.fillMaxWidth()
+  ) {
+    Text(stringResource(start), fontSize = 24.sp)
+  }
+
+  Button(
+    onClick = {
+      if (isPaused) hitTimer.resume() else hitTimer.pause()
+      onPausedChange(!isPaused)
+    },
+    Modifier.fillMaxWidth(),
+    enabled = millisElapsed > 0
+  ) {
+    Text(stringResource(if (isPaused) resume else pause), fontSize = 24.sp)
+  }
+
+  Button(
+    onClick = {
+      hitTimer.reset()
+      onPausedChange(false)
+    },
+    Modifier.fillMaxWidth()
+  ) {
+    Text(stringResource(reset), fontSize = 24.sp)
   }
 }
 

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
@@ -3,6 +3,7 @@ package br.com.colman.petals.hittimer
 import android.os.Parcelable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import org.apache.commons.lang3.time.DurationFormatUtils
@@ -17,13 +18,21 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
   @IgnoredOnParcel
   private var startDate: LocalDateTime? = null
 
+  /**
+   * How long the current hit has been held. Unlike [millisLeft] this keeps counting past
+   * [durationMillis], because the point of the ten second target is that going over it costs you,
+   * and you cannot see that you went over if the timer stops at the target.
+   */
   @IgnoredOnParcel
-  val millisLeft = flow {
+  val millisElapsed = flow {
     while (true) {
-      emit(calculateMillisLeft())
+      emit(calculateMillisElapsed())
       delay(100)
     }
   }
+
+  @IgnoredOnParcel
+  val millisLeft = millisElapsed.map { (durationMillis - it).coerceAtLeast(0) }
 
   fun start() {
     startDate = now()
@@ -33,10 +42,9 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
     startDate = null
   }
 
-  private fun calculateMillisLeft(): Long {
-    if (startDate == null) return durationMillis
-    val elapsed = startDate?.until(now(), MILLIS) ?: 0
-    return (durationMillis - elapsed).coerceAtLeast(0)
+  private fun calculateMillisElapsed(): Long {
+    val start = startDate ?: return 0
+    return start.until(now(), MILLIS).coerceAtLeast(0)
   }
 
   companion object {

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
@@ -18,6 +18,10 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
   @IgnoredOnParcel
   private var startDate: LocalDateTime? = null
 
+  /** Time banked by previous runs, so pausing can freeze a reading without discarding it. */
+  @IgnoredOnParcel
+  private var accumulatedMillis: Long = 0
+
   /**
    * How long the current hit has been held. Unlike [millisLeft] this keeps counting past
    * [durationMillis], because the point of the ten second target is that going over it costs you,
@@ -35,16 +39,28 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
   val millisLeft = millisElapsed.map { (durationMillis - it).coerceAtLeast(0) }
 
   fun start() {
+    accumulatedMillis = 0
     startDate = now()
   }
 
+  /** Freezes the reading where it is. Without this the elapsed hold would climb until [reset] wiped it. */
+  fun pause() {
+    accumulatedMillis = calculateMillisElapsed()
+    startDate = null
+  }
+
+  fun resume() {
+    if (startDate == null) startDate = now()
+  }
+
   fun reset() {
+    accumulatedMillis = 0
     startDate = null
   }
 
   private fun calculateMillisElapsed(): Long {
-    val start = startDate ?: return 0
-    return start.until(now(), MILLIS).coerceAtLeast(0)
+    val start = startDate ?: return accumulatedMillis
+    return accumulatedMillis + start.until(now(), MILLIS).coerceAtLeast(0)
   }
 
   companion object {

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/WhyTenSeconds.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/WhyTenSeconds.kt
@@ -1,17 +1,24 @@
 package br.com.colman.petals.hittimer
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -23,6 +30,7 @@ import br.com.colman.petals.R.color.lightGreen
 import br.com.colman.petals.R.string._175thc
 import br.com.colman.petals.R.string._355thc
 import br.com.colman.petals.R.string.breathhold_duration_seconds
+import br.com.colman.petals.R.string.current_hold
 import br.com.colman.petals.R.string.subjectve_high
 import br.com.colman.petals.R.string.ten_seconds_introduction
 import br.com.colman.petals.R.string.ten_seconds_source
@@ -30,63 +38,52 @@ import br.com.colman.petals.R.string.why_ten_seconds
 import com.jjoe64.graphview.GraphView
 import com.jjoe64.graphview.series.DataPoint
 import com.jjoe64.graphview.series.LineGraphSeries
+import com.jjoe64.graphview.series.PointsGraphSeries
 
+/** [holdSeconds] is how long the current hit has been held, marked on both curves as it runs. */
 @Preview
 @Composable
-fun WhyTenSeconds() {
+fun WhyTenSeconds(holdSeconds: Double = 0.0) {
   Card(Modifier.fillMaxWidth().padding(16.dp)) {
     Column(Modifier.fillMaxWidth().padding(16.dp), Arrangement.spacedBy(16.dp)) {
       Text(stringResource(why_ten_seconds), fontSize = 24.sp)
       Text(stringResource(ten_seconds_introduction), fontSize = 18.sp)
 
       Box(Modifier.height(300.dp)) {
-        SubjectiveHigh()
+        SubjectiveHigh(holdSeconds)
       }
+      SubjectiveHighLegend()
 
       Text(stringResource(ten_seconds_source), fontSize = 12.sp)
     }
   }
 }
 
+private const val ChartMaxX = 25.0
+
 @Composable
-fun SubjectiveHigh() {
+fun SubjectiveHigh(holdSeconds: Double = 0.0) {
   val primaryColor = MaterialTheme.colors.primary.toArgb()
-  val backgroundColor = MaterialTheme.colors.background.toArgb()
 
   AndroidView({ context ->
     GraphView(context).apply {
-      addSeries(
-        LineGraphSeries(getSubjectiveHighWeakSeries().toTypedArray()).apply {
-          // TODO Replace with color from color palette
-          color = ContextCompat.getColor(context, lightGreen)
-          isDrawDataPoints = true
-          title = context.getString(_175thc)
-        }
-      )
-
-      addSeries(
-        LineGraphSeries(getSubjectiveHighStrongSeries().toTypedArray()).apply {
-          // TODO Replace with color from color palette
-          color = ContextCompat.getColor(context, darkGreen)
-          isDrawDataPoints = true
-          title = context.getString(_355thc)
-        }
-      )
+      // The curves are added here, not in update: GridLabelRenderer sizes the axis labels on the first
+      // layout pass, and a GraphView that starts empty lays the horizontal title over the tick numbers.
+      addCurve(getSubjectiveHighWeakSeries(), ContextCompat.getColor(context, lightGreen), context.getString(_175thc))
+      addCurve(getSubjectiveHighStrongSeries(), ContextCompat.getColor(context, darkGreen), context.getString(_355thc))
 
       viewport.apply {
         isYAxisBoundsManual = true
         setMaxY(60.0)
         setMinY(0.0)
         isXAxisBoundsManual = true
-        setMaxX(25.0)
+        setMaxX(ChartMaxX)
         setMinX(0.0)
       }
 
-      legendRenderer.apply {
-        this.backgroundColor = backgroundColor
-        textColor = primaryColor
-        isVisible = true
-      }
+      // Drawn in Compose instead: GraphView's legend paints a colour swatch for every series,
+      // including the untitled hold markers, and its box sits on top of the curves.
+      legendRenderer.isVisible = false
 
       gridLabelRenderer.apply {
         verticalLabelsColor = primaryColor
@@ -98,7 +95,70 @@ fun SubjectiveHigh() {
         horizontalAxisTitle = context.getString(breathhold_duration_seconds)
       }
     }
+  }, update = { graph ->
+    // Only the markers move, so only the markers are replaced. The curves stay as laid out.
+    graph.series.filterIsInstance<PointsGraphSeries<DataPoint>>().forEach(graph::removeSeries)
+
+    // Both markers in the accent colour, so "where you are" reads as one thing against the two curves.
+    graph.addHoldMarker(getSubjectiveHighWeakSeries(), holdSeconds, primaryColor)
+    graph.addHoldMarker(getSubjectiveHighStrongSeries(), holdSeconds, primaryColor)
   })
+}
+
+@Composable
+private fun SubjectiveHighLegend() {
+  Row(Modifier.fillMaxWidth(), Arrangement.spacedBy(16.dp)) {
+    LegendEntry(colorResource(lightGreen), stringResource(_175thc))
+    LegendEntry(colorResource(darkGreen), stringResource(_355thc))
+    LegendEntry(MaterialTheme.colors.primary, stringResource(current_hold))
+  }
+}
+
+@Composable
+private fun LegendEntry(swatch: Color, label: String) {
+  Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+    Box(Modifier.size(12.dp).background(swatch, CircleShape))
+    Text(label, fontSize = 12.sp)
+  }
+}
+
+private fun GraphView.addCurve(points: List<DataPoint>, seriesColor: Int, seriesTitle: String) {
+  addSeries(
+    LineGraphSeries(points.toTypedArray()).apply {
+      color = seriesColor
+      isDrawDataPoints = true
+      title = seriesTitle
+    }
+  )
+}
+
+/** Deliberately left untitled so it does not add a third entry to the legend. */
+private fun GraphView.addHoldMarker(points: List<DataPoint>, holdSeconds: Double, markerColor: Int) {
+  val (x, y) = holdPointOn(points, holdSeconds, ChartMaxX)
+  addSeries(
+    PointsGraphSeries(arrayOf(DataPoint(x, y))).apply {
+      color = markerColor
+      size = 15f
+      shape = PointsGraphSeries.Shape.POINT
+    }
+  )
+}
+
+/**
+ * Where a hold of [holdSeconds] sits on [points]: x clamped into the chart, y linearly interpolated
+ * between the study's measurements. Pure - no Android, no Compose - so it is unit-testable.
+ */
+fun holdPointOn(points: List<DataPoint>, holdSeconds: Double, maxX: Double): Pair<Double, Double> {
+  val sorted = points.sortedBy { it.x }
+  val x = holdSeconds.coerceIn(sorted.first().x, minOf(maxX, sorted.last().x))
+
+  val upperIndex = sorted.indexOfFirst { it.x >= x }.coerceAtLeast(1)
+  val lower = sorted[upperIndex - 1]
+  val upper = sorted[upperIndex]
+
+  val span = upper.x - lower.x
+  val y = if (span == 0.0) upper.y else lower.y + (upper.y - lower.y) * (x - lower.x) / span
+  return x to y
 }
 
 /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,7 @@
     <string name="subjectve_high">Subjective \"High\"</string>
     <string name="breathhold_duration_seconds">Breathhold Duration (seconds)</string>
     <string name="current_hold">Your hold</string>
+    <string name="holding_past_peak">Holding for %1$s s, past the peak</string>
     <string name="_175thc" formatted="false">1.75% THC</string>
     <string name="_355thc" formatted="false">3.55% THC</string>
     <string name="add_use">Add Use</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="hit_timer">Hit Timer</string>
     <string name="start">Start</string>
     <string name="reset">Reset</string>
+    <string name="pause">Pause</string>
+    <string name="resume">Resume</string>
     <string name="ten_seconds_introduction">Holding for more than 10 seconds will not increase your high, but will increase bad things that weed cause to you.</string>
     <string name="ten_seconds_source">Source: Azorlosa JL, Greenwald MK, Stitzer ML. Marijuana smoking: effects of varying puff volume and breathhold duration. J Pharmacol Exp Ther. 1995. Feb;272(2):560–9. PMID: 7853169.</string>
     <string name="why_ten_seconds">Why 10 seconds?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="why_ten_seconds">Why 10 seconds?</string>
     <string name="subjectve_high">Subjective \"High\"</string>
     <string name="breathhold_duration_seconds">Breathhold Duration (seconds)</string>
+    <string name="current_hold">Your hold</string>
     <string name="_175thc" formatted="false">1.75% THC</string>
     <string name="_355thc" formatted="false">3.55% THC</string>
     <string name="add_use">Add Use</string>

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
@@ -140,4 +140,55 @@ class HitTimerTest : FunSpec({
       target.millisElapsed.first() shouldBe 0
     }
   }
+
+  context("Pause") {
+    test("Freezes the reading instead of losing it, which reset would") {
+      target.start()
+      delay(duration * 2)
+      target.pause()
+
+      val frozen = target.millisElapsed.first()
+      frozen shouldBeGreaterThanOrEqual (duration * 2)
+
+      delay(duration * 2)
+      target.millisElapsed.take(3).toList().forAll { it shouldBe frozen }
+    }
+
+    test("Resume carries on from the frozen reading") {
+      target.start()
+      delay(duration)
+      target.pause()
+      val frozen = target.millisElapsed.first()
+
+      target.resume()
+      delay(duration)
+
+      target.millisElapsed.first() shouldBeGreaterThanOrEqual (frozen + duration / 2)
+    }
+
+    test("Start after a pause counts from scratch") {
+      target.start()
+      delay(duration * 2)
+      target.pause()
+      target.start()
+
+      target.millisElapsed.first() shouldBeLessThanOrEqual duration
+    }
+
+    test("Reset clears a paused reading") {
+      target.start()
+      delay(duration)
+      target.pause()
+      target.reset()
+
+      target.millisElapsed.first() shouldBe 0
+    }
+
+    test("Pausing before starting leaves it at zero") {
+      target.pause()
+
+      target.millisElapsed.first() shouldBe 0
+      target.millisLeft.first() shouldBe duration
+    }
+  }
 })

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
@@ -5,6 +5,7 @@ import io.kotest.datatest.withData
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldBeMonotonicallyDecreasing
 import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.longs.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
@@ -106,5 +107,37 @@ class HitTimerTest : FunSpec({
     delay(duration)
     target.millisLeft.first() shouldBe 0
     target.millisLeft.take(3).toList().forAll { it shouldBe 0 }
+  }
+
+  context("Elapsed hold") {
+    test("Is zero before the timer is started") {
+      target.millisElapsed.take(3).toList().forAll { it shouldBe 0 }
+    }
+
+    test("Keeps counting past the target, which the countdown cannot show") {
+      target.start()
+      delay(duration * 3)
+
+      val elapsed = target.millisElapsed.first()
+      elapsed shouldBeGreaterThanOrEqual (duration * 3)
+      target.millisLeft.first() shouldBe 0
+    }
+
+    test("Grows while the countdown is still running") {
+      target.start()
+      val first = target.millisElapsed.first()
+      delay(30L)
+      val second = target.millisElapsed.first()
+
+      second shouldBeGreaterThanOrEqual first
+    }
+
+    test("Goes back to zero on reset") {
+      target.start()
+      delay(duration * 2)
+      target.reset()
+
+      target.millisElapsed.first() shouldBe 0
+    }
   }
 })

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HoldMarkerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HoldMarkerTest.kt
@@ -53,9 +53,9 @@ class HoldMarkerTest : FunSpec({
     holdPointOn(shuffled, 5.0, 25.0) shouldBe holdPointOn(weak, 5.0, 25.0)
   }
 
-  test("Hold seconds are the elapsed side of the countdown") {
-    holdSecondsOf(millisLeft = 10_000, durationMillis = 10_000) shouldBe 0.0
-    holdSecondsOf(millisLeft = 7_500, durationMillis = 10_000) shouldBe 2.5
-    holdSecondsOf(millisLeft = 0, durationMillis = 10_000) shouldBe 10.0
+  test("Overtime walks the marker down the far side of the peak") {
+    val peak = holdPointOn(weak, 10.0, 25.0).second
+
+    listOf(12.0, 15.0, 18.0).map { holdPointOn(weak, it, 25.0).second }.forEach { (it < peak) shouldBe true }
   }
 })

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HoldMarkerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HoldMarkerTest.kt
@@ -1,0 +1,61 @@
+package br.com.colman.petals.hittimer
+
+import com.jjoe64.graphview.series.DataPoint
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.doubles.plusOrMinus
+import io.kotest.matchers.shouldBe
+
+class HoldMarkerTest : FunSpec({
+
+  val weak = getSubjectiveHighWeakSeries()
+
+  test("At rest the marker sits at the start of the curve") {
+    holdPointOn(weak, 0.0, 25.0) shouldBe (0.0 to 30.0)
+  }
+
+  test("The marker interpolates between the study's measurements") {
+    val (x, y) = holdPointOn(weak, 5.0, 25.0)
+
+    x shouldBe (5.0 plusOrMinus 1e-9)
+    y shouldBe (35.0 plusOrMinus 1e-9)
+  }
+
+  test("The marker lands on the peak at ten seconds, which is the whole point of the chart") {
+    holdPointOn(weak, 10.0, 25.0) shouldBe (10.0 to 40.0)
+    holdPointOn(getSubjectiveHighStrongSeries(), 10.0, 25.0) shouldBe (10.0 to 47.0)
+  }
+
+  test("Past the peak the marker descends, showing a longer hold buys less") {
+    val peak = holdPointOn(weak, 10.0, 25.0).second
+    val late = holdPointOn(weak, 15.0, 25.0).second
+
+    late shouldBe (37.5 plusOrMinus 1e-9)
+    (late < peak) shouldBe true
+  }
+
+  test("A hold longer than the study's data stops at its last measurement") {
+    holdPointOn(weak, 40.0, 25.0) shouldBe (20.0 to 35.0)
+  }
+
+  test("The marker never leaves the visible chart") {
+    val (x, _) = holdPointOn(weak, 40.0, 15.0)
+
+    x shouldBe (15.0 plusOrMinus 1e-9)
+  }
+
+  test("A negative hold is pulled back to the start") {
+    holdPointOn(weak, -5.0, 25.0) shouldBe (0.0 to 30.0)
+  }
+
+  test("Unordered points are handled") {
+    val shuffled = listOf(DataPoint(20.0, 35.0), DataPoint(0.0, 30.0), DataPoint(10.0, 40.0))
+
+    holdPointOn(shuffled, 5.0, 25.0) shouldBe holdPointOn(weak, 5.0, 25.0)
+  }
+
+  test("Hold seconds are the elapsed side of the countdown") {
+    holdSecondsOf(millisLeft = 10_000, durationMillis = 10_000) shouldBe 0.0
+    holdSecondsOf(millisLeft = 7_500, durationMillis = 10_000) shouldBe 2.5
+    holdSecondsOf(millisLeft = 0, durationMillis = 10_000) shouldBe 10.0
+  }
+})


### PR DESCRIPTION
## Why

The Hit Timer counted down next to a chart of subjective high against breathhold duration, and nothing connected the two. You could read that the peak is at ten seconds without ever seeing where your current hit sat against it.

Worse, the countdown floored at zero: hold for eighteen seconds and the app still said ten. That is precisely the half of the curve where the study says you get **no extra high and keep taking in smoke**, and it was the half you could never see yourself on.

## What

**A marker on both curves, tracking the hold as it runs.**

<img src="https://raw.githubusercontent.com/LeoColman/Petals/assets/pr-hit-timer/hit-timer/marker-running.png" width="330">

**The timer keeps counting past the target.** Past ten seconds a second line reports the real hold, and the markers walk *down* the far side of the peak rather than parking on it. That descent is the damage-reduction argument made visible.

<img src="https://raw.githubusercontent.com/LeoColman/Petals/assets/pr-hit-timer/hit-timer/overtime.png" width="330">

**A pause button**, because an unbounded counter that only Reset can stop is useless: Reset wipes the number you wanted to read.

<img src="https://raw.githubusercontent.com/LeoColman/Petals/assets/pr-hit-timer/hit-timer/pause-cycle.png" width="620">

Frozen at 16.3 s and still 16.3 s six seconds later. Resume continues from the frozen value (16.3 → 21.3 after five seconds), Start always begins a fresh hit, and Pause is disabled until there is something to freeze.

This came from a user request for a pause button "so I can at least see my current hit holding time". I initially argued against it — nobody presses a button mid-hit — which missed that you press it *after* exhaling. Letting the counter run unbounded is what turned it from optional into necessary.

## Two library problems this ran into

**GraphView's legend paints a swatch for every series.** Confirmed in the bytecode: `drawRect` runs unconditionally and only `drawText` checks `getTitle() != null`, so untitled markers showed as blank squares. It also reads `SecondScale.getSeries()`, so there is no escaping via a second axis. The legend is now drawn in Compose, which also labels the marker and stops the legend box from covering the curves.

<img src="https://raw.githubusercontent.com/LeoColman/Petals/assets/pr-hit-timer/hit-timer/legend.png" width="330">

**GridLabelRenderer sizes axis labels on the first layout pass.** Building the curves in `AndroidView`'s update block instead of its factory left the GraphView empty at that moment, and the horizontal axis title landed on top of the tick numbers. The curves stay in the factory; only the markers are swapped in update.

## Vibration

`ctx.vibrate()` was checked inline in the composable body. That was harmless only because `millisLeft` froze at zero and `collectAsState` stops recomposing when a value stops changing. With an elapsed counter that never freezes, the inline check buzzes every hundred milliseconds, forever. It is now in a `LaunchedEffect` keyed on the crossing.

Verified on device rather than assumed: the emulator logs nothing for vibration in either logcat or `dumpsys vibrator_manager`, so I instrumented `vibrate()` temporarily and counted. **One call across eight seconds of overtime**, where the inline version would have made about eighty. The probe was removed before committing.

## Testing

Unit tests for the marker geometry (interpolation, both clamps, unordered input, the descent past the peak) and for the timer's elapsed and pause behaviour. Detekt clean. Every state above was walked on a Pixel_9a emulator, with button coordinates read from `uiautomator dump` — my first pass tapped Start instead of Pause because the new overtime line shifts the buttons down.

Screenshots live on `assets/pr-hit-timer`; delete it whenever this merges.

## Not in this PR

Average hold time over 7/30 days, from the same user request. It only becomes meaningful now that the counter is unbounded — before this, every average would saturate at ten seconds and measure nothing. It needs a table and a migration, so it belongs on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZhzG934mSYQb7hsQweWkk