### PR TITLE
✨ Record hits and show your average hold

### DIFF
--- a/app/src/main/kotlin/br/com/colman/petals/KoinModule.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/KoinModule.kt
@@ -23,6 +23,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import br.com.colman.petals.hittimer.HitTimerRepository
+import br.com.colman.petals.hittimer.repository.HitRepository
 import br.com.colman.petals.review.ReviewAppRequester
 import br.com.colman.petals.settings.SettingsRepository
 import br.com.colman.petals.use.io.UseIOModules
@@ -56,6 +57,7 @@ val KoinModule = module {
   single { object : ReviewAppRequester {} } bind ReviewAppRequester::class
   single { UseRepository(get<Database>().useQueries) }
   single { PauseRepository(get<Database>().pauseQueries) }
+  single { HitRepository(get<Database>().hitQueries) }
   single { HitTimerRepository(get<Context>().hitTimerPreferencesDataStore) }
   single { SettingsRepository(get<Context>().settingsDatastore) }
   single { CensorshipRepository(get<Context>().blockDataStore) }

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
@@ -64,14 +64,20 @@ import br.com.colman.petals.R.string.reset
 import br.com.colman.petals.R.string.resume
 import br.com.colman.petals.R.string.start
 import br.com.colman.petals.R.string.vibrate_on_timer_end
+import br.com.colman.petals.hittimer.repository.HitRepository
+import br.com.colman.petals.hittimer.repository.record
 import br.com.colman.petals.settings.SettingsRepository
 import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
+import java.time.LocalDateTime
 import java.util.Locale
 
 @Preview
 @Composable
-fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
+fun ComposeHitTimer(
+  repository: HitTimerRepository = koinInject(),
+  hitRepository: HitRepository = koinInject()
+) {
   val hitTimer = rememberSaveable { HitTimer() }
   // While paused the elapsed value stops changing, so nothing recomposes: the label needs its own state.
   var isPaused by rememberSaveable { mutableStateOf(false) }
@@ -79,6 +85,10 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
   val ctx = LocalContext.current
   val millisElapsed by hitTimer.millisElapsed.collectAsState(0L)
   val shouldVibrate by repository.shouldVibrate.collectAsState(false)
+
+  val hits by hitRepository.all().collectAsState(emptyList())
+  val averages = remember(hits) { holdAverages(hits, LocalDateTime.now()) }
+  val recordHit = { hitRepository.record(hitTimer) }
 
   val millisLeft = (hitTimer.durationMillis - millisElapsed).coerceAtLeast(0)
   val alpha = millisLeft.toFloat() / hitTimer.durationMillis
@@ -106,7 +116,7 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
     HoldOvertime(millisElapsed, hitTimer.durationMillis)
 
     Column(Modifier.width(180.dp), spacedBy(8.dp)) {
-      TimerButtons(hitTimer, millisElapsed, isPaused) { isPaused = it }
+      TimerButtons(hitTimer, millisElapsed, isPaused, recordHit) { isPaused = it }
 
       Row(Modifier.fillMaxWidth(), Start, CenterVertically) {
         Checkbox(shouldVibrate, { repository.setShouldVibrate(it) })
@@ -114,6 +124,7 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
       }
     }
     WhyTenSeconds(millisElapsed / 1000.0)
+    HoldAveragesCard(averages)
   }
 }
 
@@ -123,14 +134,18 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
  * to freeze.
  */
 @Composable
+@Suppress("LongParameterList")
 private fun TimerButtons(
   hitTimer: HitTimer,
   millisElapsed: Long,
   isPaused: Boolean,
+  onRecord: () -> Unit,
   onPausedChange: (Boolean) -> Unit
 ) {
+  // Every exit from a run records it, and the run's id keeps that from writing more than one row.
   Button(
     onClick = {
+      onRecord()
       hitTimer.start()
       onPausedChange(false)
     },
@@ -141,7 +156,12 @@ private fun TimerButtons(
 
   Button(
     onClick = {
-      if (isPaused) hitTimer.resume() else hitTimer.pause()
+      if (isPaused) {
+        hitTimer.resume()
+      } else {
+        hitTimer.pause()
+        onRecord()
+      }
       onPausedChange(!isPaused)
     },
     Modifier.fillMaxWidth(),
@@ -152,6 +172,7 @@ private fun TimerButtons(
 
   Button(
     onClick = {
+      onRecord()
       hitTimer.reset()
       onPausedChange(false)
     },

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HitTimer.kt
@@ -11,6 +11,7 @@ import java.time.LocalDateTime
 import java.time.LocalDateTime.now
 import java.time.temporal.ChronoUnit.MILLIS
 import java.util.Locale
+import java.util.UUID
 
 @Parcelize
 class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
@@ -21,6 +22,17 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
   /** Time banked by previous runs, so pausing can freeze a reading without discarding it. */
   @IgnoredOnParcel
   private var accumulatedMillis: Long = 0
+
+  /**
+   * Identifies the current hit. Stable across pause and resume so that recording it repeatedly updates
+   * one row rather than logging the same hit several times; a new one is minted by [start].
+   */
+  @IgnoredOnParcel
+  var runId: String = UUID.randomUUID().toString()
+    private set
+
+  /** The reading as it stands, for callers that need it at the instant of a button press. */
+  fun elapsedMillis(): Long = calculateMillisElapsed()
 
   /**
    * How long the current hit has been held. Unlike [millisLeft] this keeps counting past
@@ -39,6 +51,7 @@ class HitTimer(val durationMillis: Long = 10_000L) : Parcelable {
   val millisLeft = millisElapsed.map { (durationMillis - it).coerceAtLeast(0) }
 
   fun start() {
+    runId = UUID.randomUUID().toString()
     accumulatedMillis = 0
     startDate = now()
   }

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HoldAverages.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HoldAverages.kt
@@ -1,0 +1,36 @@
+package br.com.colman.petals.hittimer
+
+import br.com.colman.petals.hittimer.repository.Hit
+import java.time.Duration
+import java.time.LocalDateTime
+
+/** Windows the hold average is reported over, longest first. */
+enum class HoldWindow(val days: Long?) {
+  AllTime(null),
+  Last30Days(30),
+  Last7Days(7)
+}
+
+/**
+ * @param average null when the window holds no hits, which reads differently from an average of zero
+ */
+data class HoldAverage(val window: HoldWindow, val average: Duration?, val count: Int)
+
+/**
+ * Mean hold per window. Pure, so it is unit-testable, and the only place the windows are defined.
+ *
+ * Hits after [now] are ignored rather than trusted: the date picker elsewhere in the app allows future
+ * dates, and a clock that moved backwards would otherwise drag the average.
+ */
+fun holdAverages(hits: List<Hit>, now: LocalDateTime): List<HoldAverage> =
+  HoldWindow.entries.map { window ->
+    val cutoff = window.days?.let { now.minusDays(it) }
+    val inWindow = hits.filter { !it.date.isAfter(now) && (cutoff == null || !it.date.isBefore(cutoff)) }
+
+    HoldAverage(window, inWindow.meanDuration(), inWindow.size)
+  }
+
+private fun List<Hit>.meanDuration(): Duration? {
+  if (isEmpty()) return null
+  return Duration.ofMillis(sumOf { it.duration.toMillis() } / size)
+}

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/HoldAveragesCard.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/HoldAveragesCard.kt
@@ -1,0 +1,74 @@
+package br.com.colman.petals.hittimer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import br.com.colman.petals.R.plurals.amount_hits
+import br.com.colman.petals.R.plurals.last_x_days
+import br.com.colman.petals.R.string.all_time
+import br.com.colman.petals.R.string.average_hold
+import br.com.colman.petals.R.string.average_hold_explanation
+import br.com.colman.petals.R.string.seconds_short
+import br.com.colman.petals.hittimer.HoldWindow.AllTime
+import java.time.Duration
+import java.util.Locale
+
+/** Nothing recorded yet means nothing to say, so the card stays away until there is a hit. */
+@Composable
+fun HoldAveragesCard(averages: List<HoldAverage>) {
+  if (averages.none { it.count > 0 }) return
+
+  Card(Modifier.fillMaxWidth().padding(16.dp)) {
+    Column(Modifier.fillMaxWidth().padding(16.dp), Arrangement.spacedBy(12.dp)) {
+      Text(stringResource(average_hold), fontSize = 24.sp)
+      Text(stringResource(average_hold_explanation), fontSize = 14.sp)
+
+      averages.forEach { HoldAverageRow(it) }
+    }
+  }
+}
+
+@Composable
+private fun HoldAverageRow(average: HoldAverage) {
+  Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
+    Text(average.window.label(), fontSize = 16.sp)
+    Text(
+      average.average?.let { stringResource(seconds_short, it.asSecondsText()) } ?: "-",
+      fontSize = 16.sp,
+      color = MaterialTheme.colors.primary
+    )
+    Text(pluralStringResource(amount_hits, average.count, average.count), fontSize = 16.sp)
+  }
+}
+
+@Composable
+private fun HoldWindow.label(): String = when (val windowDays = days) {
+  null -> stringResource(all_time)
+  else -> pluralStringResource(last_x_days, windowDays.toInt(), windowDays)
+}
+
+private fun Duration.asSecondsText() = "%.1f".format(Locale.US, toMillis() / 1000.0)
+
+@Preview
+@Composable
+private fun HoldAveragesCardPreview() {
+  HoldAveragesCard(
+    listOf(
+      HoldAverage(AllTime, Duration.ofMillis(12_400), 37),
+      HoldAverage(HoldWindow.Last30Days, Duration.ofMillis(11_100), 21),
+      HoldAverage(HoldWindow.Last7Days, Duration.ofMillis(9_800), 6)
+    )
+  )
+}

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/repository/Hit.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/repository/Hit.kt
@@ -1,0 +1,15 @@
+package br.com.colman.petals.hittimer.repository
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * One recorded breathhold. [id] is stable for the duration of a run, so pausing, resuming and pausing
+ * again updates the same row instead of logging the same hit several times.
+ */
+data class Hit(
+  val date: LocalDateTime,
+  val duration: Duration,
+  val id: String = UUID.randomUUID().toString()
+)

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/repository/HitRepository.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/repository/HitRepository.kt
@@ -1,0 +1,47 @@
+package br.com.colman.petals.hittimer.repository
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import br.com.colman.petals.HitQueries
+import br.com.colman.petals.hittimer.HitTimer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.LocalDateTime.parse
+import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
+import br.com.colman.petals.Hit as HitEntity
+
+class HitRepository(
+  private val hitQueries: HitQueries
+) {
+
+  /** Inserts, or updates the row already written for this run. Future-dated rows are excluded on read. */
+  fun upsert(hit: Hit) {
+    hitQueries.upsert(hit.toEntity())
+  }
+
+  fun all(dispatcher: CoroutineDispatcher = IO): Flow<List<Hit>> =
+    hitQueries.selectAll().asFlow().mapToList(dispatcher).map { it.map(HitEntity::toHit) }
+
+  fun deleteAll() {
+    hitQueries.deleteAll()
+  }
+}
+
+/**
+ * Records the timer's current run, if it has one. Keyed on the run's id, so calling this on pause and
+ * again on reset updates a single row rather than logging the same hit twice.
+ */
+fun HitRepository.record(hitTimer: HitTimer, now: LocalDateTime = LocalDateTime.now()) {
+  val elapsed = hitTimer.elapsedMillis()
+  if (elapsed <= 0) return
+
+  upsert(Hit(now, Duration.ofMillis(elapsed), hitTimer.runId))
+}
+
+fun Hit.toEntity(): HitEntity = HitEntity(id, date.format(ISO_LOCAL_DATE_TIME), duration.toMillis())
+
+fun HitEntity.toHit() = Hit(parse(date), Duration.ofMillis(duration_millis), id)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,13 @@
     <string name="reset">Reset</string>
     <string name="pause">Pause</string>
     <string name="resume">Resume</string>
+    <string name="average_hold">Your average hold</string>
+    <string name="average_hold_explanation">Recorded whenever you pause or reset the timer. The study puts the peak at 10 seconds, so an average well above that is smoke you are taking in for no extra effect.</string>
+    <string name="seconds_short">%1$s s</string>
+    <plurals name="amount_hits">
+        <item quantity="one">%s hit</item>
+        <item quantity="other">%s hits</item>
+    </plurals>
     <string name="ten_seconds_introduction">Holding for more than 10 seconds will not increase your high, but will increase bad things that weed cause to you.</string>
     <string name="ten_seconds_source">Source: Azorlosa JL, Greenwald MK, Stitzer ML. Marijuana smoking: effects of varying puff volume and breathhold duration. J Pharmacol Exp Ther. 1995. Feb;272(2):560–9. PMID: 7853169.</string>
     <string name="why_ten_seconds">Why 10 seconds?</string>

--- a/app/src/main/sqldelight/br/com/colman/petals/Hit.sq
+++ b/app/src/main/sqldelight/br/com/colman/petals/Hit.sq
@@ -1,0 +1,16 @@
+CREATE TABLE Hit(
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  duration_millis INTEGER NOT NULL
+);
+
+upsert:
+INSERT INTO Hit(id, date, duration_millis) VALUES ?
+ON CONFLICT (id) DO UPDATE SET date = excluded.date,
+ duration_millis = excluded.duration_millis;
+
+selectAll:
+SELECT * FROM Hit WHERE datetime(date) <= datetime('now', 'localtime') ORDER BY date ASC;
+
+deleteAll:
+DELETE FROM Hit;

--- a/app/src/main/sqldelight/migrations/5.sqm
+++ b/app/src/main/sqldelight/migrations/5.sqm
@@ -1,0 +1,5 @@
+CREATE TABLE Hit(
+  id TEXT PRIMARY KEY,
+  date TEXT NOT NULL,
+  duration_millis INTEGER NOT NULL
+);

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HitTimerTest.kt
@@ -191,4 +191,23 @@ class HitTimerTest : FunSpec({
       target.millisLeft.first() shouldBe duration
     }
   }
+
+  context("Run id") {
+    test("Survives a pause and resume, so one hit is recorded once") {
+      target.start()
+      val id = target.runId
+      target.pause()
+      target.resume()
+
+      target.runId shouldBe id
+    }
+
+    test("Changes on start, so the next hit is recorded separately") {
+      target.start()
+      val first = target.runId
+      target.start()
+
+      (target.runId == first) shouldBe false
+    }
+  }
 })

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/HoldAveragesTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/HoldAveragesTest.kt
@@ -1,0 +1,79 @@
+package br.com.colman.petals.hittimer
+
+import br.com.colman.petals.hittimer.HoldWindow.AllTime
+import br.com.colman.petals.hittimer.HoldWindow.Last30Days
+import br.com.colman.petals.hittimer.HoldWindow.Last7Days
+import br.com.colman.petals.hittimer.repository.Hit
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import java.time.Duration
+import java.time.LocalDateTime
+
+private val Now: LocalDateTime = LocalDateTime.of(2026, 1, 31, 12, 0)
+
+private fun hit(daysAgo: Long, seconds: Double) =
+  Hit(Now.minusDays(daysAgo), Duration.ofMillis((seconds * 1000).toLong()))
+
+private fun List<HoldAverage>.of(window: HoldWindow) = single { it.window == window }
+
+class HoldAveragesTest : FunSpec({
+
+  test("No hits leaves every window empty rather than averaging zero") {
+    holdAverages(emptyList(), Now).forEach {
+      it.average.shouldBeNull()
+      it.count shouldBe 0
+    }
+  }
+
+  test("Every window is reported, longest first") {
+    holdAverages(emptyList(), Now).map { it.window } shouldBe listOf(AllTime, Last30Days, Last7Days)
+  }
+
+  test("Averages only the hits inside each window") {
+    val hits = listOf(
+      hit(daysAgo = 2, seconds = 6.0),
+      hit(daysAgo = 5, seconds = 10.0),
+      hit(daysAgo = 20, seconds = 20.0),
+      hit(daysAgo = 200, seconds = 40.0)
+    )
+
+    val averages = holdAverages(hits, Now)
+
+    averages.of(Last7Days).average shouldBe Duration.ofSeconds(8)
+    averages.of(Last7Days).count shouldBe 2
+    averages.of(Last30Days).average shouldBe Duration.ofSeconds(12)
+    averages.of(Last30Days).count shouldBe 3
+    averages.of(AllTime).average shouldBe Duration.ofSeconds(19)
+    averages.of(AllTime).count shouldBe 4
+  }
+
+  test("A hit sitting exactly on the window edge is included") {
+    val averages = holdAverages(listOf(hit(daysAgo = 7, seconds = 12.0)), Now)
+
+    averages.of(Last7Days).count shouldBe 1
+    averages.of(Last7Days).average shouldBe Duration.ofSeconds(12)
+  }
+
+  test("A hit one day past the edge is not") {
+    val averages = holdAverages(listOf(hit(daysAgo = 8, seconds = 12.0)), Now)
+
+    averages.of(Last7Days).count shouldBe 0
+    averages.of(Last7Days).average.shouldBeNull()
+    averages.of(Last30Days).count shouldBe 1
+  }
+
+  test("Future dated hits are ignored, in every window") {
+    val hits = listOf(hit(daysAgo = 1, seconds = 10.0), Hit(Now.plusDays(3), Duration.ofSeconds(60)))
+
+    val averages = holdAverages(hits, Now)
+
+    averages.of(AllTime).count shouldBe 1
+    averages.of(AllTime).average shouldBe Duration.ofSeconds(10)
+  }
+
+  test("A single hit averages to itself") {
+    holdAverages(listOf(hit(daysAgo = 0, seconds = 13.5)), Now).of(AllTime).average shouldBe
+      Duration.ofMillis(13_500)
+  }
+})

--- a/app/src/test/kotlin/br/com/colman/petals/hittimer/repository/HitRepositoryTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/hittimer/repository/HitRepositoryTest.kt
@@ -1,0 +1,113 @@
+package br.com.colman.petals.hittimer.repository
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver.Companion.IN_MEMORY
+import br.com.colman.petals.Database
+import br.com.colman.petals.hittimer.HitTimer
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import java.time.Duration
+import java.time.LocalDateTime
+
+class HitRepositoryTest : FunSpec({
+
+  val database = JdbcSqliteDriver(IN_MEMORY).let {
+    Database.Schema.create(it)
+    Database(it)
+  }
+
+  val target = HitRepository(database.hitQueries)
+  val now: LocalDateTime = LocalDateTime.of(2026, 1, 31, 12, 0)
+  val hit = Hit(now.minusHours(1), Duration.ofMillis(12_345), "a-hit")
+
+  test("Stores and reads a hit back whole") {
+    target.upsert(hit)
+
+    target.all().first().single() shouldBe hit
+  }
+
+  test("Upserting the same id updates instead of duplicating") {
+    target.upsert(hit)
+    target.upsert(hit.copy(duration = Duration.ofMillis(20_000)))
+
+    val stored = target.all().first().single()
+    stored.id shouldBe "a-hit"
+    stored.duration shouldBe Duration.ofMillis(20_000)
+  }
+
+  test("Reads oldest first") {
+    val older = hit.copy(date = now.minusDays(3), id = "older")
+    val newer = hit.copy(date = now.minusDays(1), id = "newer")
+    target.upsert(newer)
+    target.upsert(older)
+
+    target.all().first().map { it.id } shouldBe listOf("older", "newer")
+  }
+
+  test("Future dated hits are not read back") {
+    target.upsert(hit.copy(date = LocalDateTime.now().plusDays(1), id = "future"))
+
+    target.all().first().shouldBeEmpty()
+  }
+
+  test("Delete all empties the table") {
+    target.upsert(hit)
+    target.deleteAll()
+
+    target.all().first().shouldBeEmpty()
+  }
+
+  context("Recording a run") {
+    test("Writes the elapsed hold under the run's id") {
+      val timer = HitTimer(100L)
+      timer.start()
+      delay(50L)
+      timer.pause()
+
+      target.record(timer, now)
+
+      val stored = target.all().first().single()
+      stored.id shouldBe timer.runId
+      (stored.duration.toMillis() >= 50L) shouldBe true
+    }
+
+    test("Recording twice in one run keeps a single hit, which is what pause then reset does") {
+      val timer = HitTimer(100L)
+      timer.start()
+      delay(50L)
+      timer.pause()
+
+      target.record(timer, now)
+      target.record(timer, now)
+
+      target.all().first().size shouldBe 1
+    }
+
+    test("A fresh run writes a separate hit") {
+      val timer = HitTimer(100L)
+      timer.start()
+      delay(30L)
+      timer.pause()
+      target.record(timer, now)
+
+      timer.start()
+      delay(30L)
+      timer.pause()
+      target.record(timer, now)
+
+      target.all().first().size shouldBe 2
+    }
+
+    test("A run that never started records nothing") {
+      target.record(HitTimer(100L), now)
+
+      target.all().first().shouldBeEmpty()
+    }
+  }
+
+  isolationMode = IsolationMode.InstancePerTest
+})


### PR DESCRIPTION
## Why

The last item from the hit timer request: *"avg hit timer of all time / last 30d / 7d"*.

I deliberately left it out of #1110 and said why there: it only becomes meaningful now that the timer no longer floors at the target. Before that change every average would have saturated at exactly ten seconds and measured nothing.

<img src="https://raw.githubusercontent.com/LeoColman/Petals/assets/pr-hit-averages/shots/averages.png" width="380">

The card names the ten second peak next to your own number, because an eighteen second average only means something against what the study says you actually gain.

## Recording

A run carries an id that survives pause and resume. Every exit from a run records it — Start over, Pause, and Reset — and the id makes that write **one row per hit** rather than one per button press.

That matters for the common flow: Start, hold, Pause to read it, then Reset is two `record()` calls for a single hit. Verified on device that it produces exactly one row.

The alternative designs all lose data: recording only on Pause loses every hit from users who never find the button, and recording only on Reset loses the hit when someone just presses Start again.

## Schema

New `Hit` table, migration `5.sqm`, schema version 6.

Verified against a **populated** database rather than a fresh install, since that is where a migration actually fails:

```
before:  user_version = 5, tables [android_metadata, Pause, Use], 360 rows in Use
after:   user_version = 6, tables [android_metadata, Pause, Use, Hit], 360 rows in Use
```

No crash in logcat.

## Testing

`holdAverages` is a pure function, so the windowing is unit-tested directly: window membership, the boundary at exactly 7 and 30 days, future-dated hits ignored, empty windows reporting null rather than an average of zero. `HitRepositoryTest` covers the upsert-not-duplicate behaviour against a real in-memory database.

End to end on a Pixel_9a, with hits seeded at 60 and 15 days back so the windows actually differ:

| window | expected | shown |
|---|---|---|
| All time | (30 + 20 + 8.1 + 16) / 4 = 18.525 | **18.5 s**, 4 hits |
| Last 30 days | (20 + 8.1 + 16) / 3 = 14.7 | **14.7 s**, 3 hits |
| Last 7 days | (8.1 + 16) / 2 = 12.05 | **12.1 s**, 2 hits |

390 unit tests, detekt clean. The screenshot branch `assets/pr-hit-averages` can go whenever this merges.

## Worth knowing

Hits are recorded silently, with no way to see or delete an individual one — unlike uses, which have a full list and CSV export. If someone leaves the timer running by accident, a 5-minute "hold" lands in the average with no way to remove it short of clearing the data. `deleteAll` exists on the repository but is not wired to any UI. Worth a follow-up if this gets used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZhzG934mSYQb7hsQweWkk