### PR TITLE
✅ Add PIT mutation testing alongside the coverage badge

### DIFF
--- a/.github/workflows/kover.main.kts
+++ b/.github/workflows/kover.main.kts
@@ -74,7 +74,9 @@ workflow(
           fi
         )
         URL="https://img.shields.io/badge/Coverage-$COVERAGE%25-$COLOR"
-        curl -sS "$URL" -o badge/coverage-badge.svg
+        # -f so an outage at shields.io fails the job instead of publishing its error page as
+        # the badge, which plain -sS would do while still exiting 0.
+        curl -fsS --retry 3 --retry-all-errors "$URL" -o badge/coverage-badge.svg
       """.trimIndent()
     )
 

--- a/.github/workflows/kover.yaml
+++ b/.github/workflows/kover.yaml
@@ -77,7 +77,9 @@ jobs:
           fi
         )
         URL="https://img.shields.io/badge/Coverage-$COVERAGE%25-$COLOR"
-        curl -sS "$URL" -o badge/coverage-badge.svg
+        # -f so an outage at shields.io fails the job instead of publishing its error page as
+        # the badge, which plain -sS would do while still exiting 0.
+        curl -fsS --retry 3 --retry-all-errors "$URL" -o badge/coverage-badge.svg
     - id: 'step-8'
       name: 'Deploy Badge to GitHub Pages'
       uses: 'peaceiris/actions-gh-pages@v4'

--- a/.github/workflows/mutation-testing.main.kts
+++ b/.github/workflows/mutation-testing.main.kts
@@ -43,12 +43,15 @@ workflow(
       action = UploadArtifact(name = "mutation-report", path = listOf("app/build/reports/pitest"))
     )
     run(
-      name = "Calculate Mutation Score",
+      name = "Calculate Test Strength",
       command = $$"""
+                STRENGTH=$(./gradlew -q printTestStrength)
                 SCORE=$(./gradlew -q printMutationScore)
-                echo "Raw Mutation Score: $SCORE"
-                SCORE=$(printf "%.0f" "$SCORE")  # Round to integer
-                echo "Rounded Mutation Score: $SCORE"
+                echo "Raw Test Strength: $STRENGTH, Raw Mutation Score: $SCORE"
+                STRENGTH=$(printf "%.0f" "$STRENGTH")  # Round to integer
+                SCORE=$(printf "%.0f" "$SCORE")
+                echo "Rounded Test Strength: $STRENGTH, Rounded Mutation Score: $SCORE"
+                echo "TEST_STRENGTH=$STRENGTH" >> $GITHUB_ENV
                 echo "MUTATION_SCORE=$SCORE" >> $GITHUB_ENV
             """.trimIndent()
     )
@@ -57,24 +60,25 @@ workflow(
       name = "Update GitHub Summary",
       command = $$"""
         echo "## Mutation Testing Report" >> $GITHUB_STEP_SUMMARY
-        echo "**Mutation Score:** $MUTATION_SCORE%" >> $GITHUB_STEP_SUMMARY
+        echo "**Test Strength:** $TEST_STRENGTH% (of the mutants a test ran, how many it caught)" >> $GITHUB_STEP_SUMMARY
+        echo "**Mutation Score:** $MUTATION_SCORE% (of every mutant, including code no test reaches)" >> $GITHUB_STEP_SUMMARY
       """.trimIndent()
     )
 
     run(
-      name = "Generate Mutation Badge",
+      name = "Generate Test Strength Badge",
       command = $$"""
         mkdir -p badge
         COLOR=$(
-          if [ "$MUTATION_SCORE" -ge 80 ]; then
+          if [ "$TEST_STRENGTH" -ge 80 ]; then
             echo "brightgreen"
-          elif [ "$MUTATION_SCORE" -ge 60 ]; then
+          elif [ "$TEST_STRENGTH" -ge 60 ]; then
             echo "yellow"
           else
             echo "red"
           fi
         )
-        URL="https://img.shields.io/badge/Mutation%20Score-$MUTATION_SCORE%25-$COLOR"
+        URL="https://img.shields.io/badge/Test%20Strength-$TEST_STRENGTH%25-$COLOR"
         curl -sS "$URL" -o badge/mutation-badge.svg
       """.trimIndent()
     )

--- a/.github/workflows/mutation-testing.main.kts
+++ b/.github/workflows/mutation-testing.main.kts
@@ -20,61 +20,62 @@ import io.github.typesafegithub.workflows.actions.peaceiris.ActionsGhPages
 import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType
 import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
 
 
 workflow(
-  name = "Kover Coverage",
-  on = listOf(Push(branches = listOf("main"))),
-  // Shared with the Mutation Testing workflow: both push a badge to the same gh-pages branch.
+  name = "Mutation Testing",
+  on = listOf(Push(branches = listOf("main")), WorkflowDispatch()),
+  // Shared with the Kover workflow: both push a badge to the same gh-pages branch.
   concurrency = Concurrency(group = "gh-pages-badges", cancelInProgress = false),
   sourceFile = __FILE__
 ) {
-  job(id = "kover-coverage", runsOn = RunnerType.UbuntuLatest) {
+  job(id = "mutation-testing", runsOn = RunnerType.UbuntuLatest) {
     uses(name = "Setup JDK", action = SetupJava(javaVersion = "17", distribution = SetupJava.Distribution.Adopt))
     uses(name = "Checkout", action = Checkout())
     uses(name = "Setup Gradle", action = ActionsSetupGradle())
 
-    run(name = "Generate Kover Reports", command = "./gradlew koverHtmlReport koverXmlReport")
+    run(name = "Run PIT Mutation Testing", command = "./gradlew pitest")
     uses(
-      name = "Upload Kover Reports",
-      action = UploadArtifact(name = "coverage-reports", path = listOf("app/build/reports/kover"))
+      name = "Upload Mutation Report",
+      action = UploadArtifact(name = "mutation-report", path = listOf("app/build/reports/pitest"))
     )
     run(
-      name = "Calculate Coverage",
+      name = "Calculate Mutation Score",
       command = $$"""
-                COVERAGE=$(./gradlew -q printLineCoverage)
-                echo "Raw Coverage: $COVERAGE"
-                COVERAGE=$(printf "%.0f" "$COVERAGE")  # Round to integer
-                echo "Rounded Coverage: $COVERAGE"
-                echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+                SCORE=$(./gradlew -q printMutationScore)
+                echo "Raw Mutation Score: $SCORE"
+                SCORE=$(printf "%.0f" "$SCORE")  # Round to integer
+                echo "Rounded Mutation Score: $SCORE"
+                echo "MUTATION_SCORE=$SCORE" >> $GITHUB_ENV
             """.trimIndent()
     )
 
     run(
       name = "Update GitHub Summary",
       command = $$"""
-        echo "## Code Coverage Report" >> $GITHUB_STEP_SUMMARY
-        echo "**Total Coverage:** $COVERAGE%" >> $GITHUB_STEP_SUMMARY
+        echo "## Mutation Testing Report" >> $GITHUB_STEP_SUMMARY
+        echo "**Mutation Score:** $MUTATION_SCORE%" >> $GITHUB_STEP_SUMMARY
       """.trimIndent()
     )
 
     run(
-      name = "Generate Coverage Badge",
+      name = "Generate Mutation Badge",
       command = $$"""
         mkdir -p badge
         COLOR=$(
-          if [ "$COVERAGE" -ge 90 ]; then
+          if [ "$MUTATION_SCORE" -ge 80 ]; then
             echo "brightgreen"
-          elif [ "$COVERAGE" -ge 70 ]; then
+          elif [ "$MUTATION_SCORE" -ge 60 ]; then
             echo "yellow"
           else
             echo "red"
           fi
         )
-        URL="https://img.shields.io/badge/Coverage-$COVERAGE%25-$COLOR"
-        curl -sS "$URL" -o badge/coverage-badge.svg
+        URL="https://img.shields.io/badge/Mutation%20Score-$MUTATION_SCORE%25-$COLOR"
+        curl -sS "$URL" -o badge/mutation-badge.svg
       """.trimIndent()
     )
 
@@ -85,7 +86,6 @@ workflow(
         publishDir = "badge",
         publishBranch = "gh-pages",
         allowEmptyCommit = false,
-        // The mutation badge lives on the same branch, so this run must not orphan it away.
         keepFiles = true
       )
     )

--- a/.github/workflows/mutation-testing.main.kts
+++ b/.github/workflows/mutation-testing.main.kts
@@ -86,7 +86,9 @@ workflow(
           fi
         )
         URL="https://img.shields.io/badge/Test%20Strength-$TEST_STRENGTH%25-$COLOR"
-        curl -sS "$URL" -o badge/test-strength-badge.svg
+        # -f so an outage at shields.io fails the job instead of publishing its error page as
+        # the badge, which plain -sS would do while still exiting 0.
+        curl -fsS --retry 3 --retry-all-errors "$URL" -o badge/test-strength-badge.svg
       """.trimIndent()
     )
 

--- a/.github/workflows/mutation-testing.main.kts
+++ b/.github/workflows/mutation-testing.main.kts
@@ -19,7 +19,8 @@ import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
 import io.github.typesafegithub.workflows.actions.peaceiris.ActionsGhPages
 import io.github.typesafegithub.workflows.domain.Concurrency
 import io.github.typesafegithub.workflows.domain.RunnerType
-import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.domain.triggers.Cron
+import io.github.typesafegithub.workflows.domain.triggers.Schedule
 import io.github.typesafegithub.workflows.domain.triggers.WorkflowDispatch
 import io.github.typesafegithub.workflows.dsl.expressions.expr
 import io.github.typesafegithub.workflows.dsl.workflow
@@ -27,7 +28,11 @@ import io.github.typesafegithub.workflows.dsl.workflow
 
 workflow(
   name = "Mutation Testing",
-  on = listOf(Push(branches = listOf("main")), WorkflowDispatch()),
+  // Weekly rather than per push. The run takes ~13 minutes, and it shares a concurrency group with
+  // the Kover workflow, so triggering it on every merge would park the coverage badge behind it —
+  // and GitHub cancels the older pending run when a third push arrives. Dispatch it by hand after
+  // a change worth measuring.
+  on = listOf(Schedule(listOf(Cron("0 5 * * 1"))), WorkflowDispatch()),
   // Shared with the Kover workflow: both push a badge to the same gh-pages branch.
   concurrency = Concurrency(group = "gh-pages-badges", cancelInProgress = false),
   sourceFile = __FILE__
@@ -40,7 +45,9 @@ workflow(
     run(name = "Run PIT Mutation Testing", command = "./gradlew pitest")
     uses(
       name = "Upload Mutation Report",
-      action = UploadArtifact(name = "mutation-report", path = listOf("app/build/reports/pitest"))
+      action = UploadArtifact(name = "mutation-report", path = listOf("app/build/reports/pitest")),
+      // A failed run is exactly when the report is worth reading.
+      condition = "always()"
     )
     run(
       name = "Calculate Test Strength",
@@ -79,7 +86,7 @@ workflow(
           fi
         )
         URL="https://img.shields.io/badge/Test%20Strength-$TEST_STRENGTH%25-$COLOR"
-        curl -sS "$URL" -o badge/mutation-badge.svg
+        curl -sS "$URL" -o badge/test-strength-badge.svg
       """.trimIndent()
     )
 

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -1,12 +1,13 @@
-# This file was generated using Kotlin DSL (.github/workflows/kover.main.kts).
+# This file was generated using Kotlin DSL (.github/workflows/mutation-testing.main.kts).
 # If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
 # Generated with https://github.com/typesafegithub/github-workflows-kt
 
-name: 'Kover Coverage'
+name: 'Mutation Testing'
 on:
   push:
     branches:
     - 'main'
+  workflow_dispatch: {}
 concurrency:
   group: 'gh-pages-badges'
   cancel-in-progress: false
@@ -20,11 +21,11 @@ jobs:
       uses: 'actions/checkout@v4'
     - id: 'step-1'
       name: 'Execute script'
-      run: 'rm ''.github/workflows/kover.yaml'' && ''.github/workflows/kover.main.kts'''
+      run: 'rm ''.github/workflows/mutation-testing.yaml'' && ''.github/workflows/mutation-testing.main.kts'''
     - id: 'step-2'
       name: 'Consistency check'
-      run: 'git diff --exit-code ''.github/workflows/kover.yaml'''
-  kover-coverage:
+      run: 'git diff --exit-code ''.github/workflows/mutation-testing.yaml'''
+  mutation-testing:
     runs-on: 'ubuntu-latest'
     needs:
     - 'check_yaml_consistency'
@@ -42,42 +43,42 @@ jobs:
       name: 'Setup Gradle'
       uses: 'gradle/actions/setup-gradle@v4'
     - id: 'step-3'
-      name: 'Generate Kover Reports'
-      run: './gradlew koverHtmlReport koverXmlReport'
+      name: 'Run PIT Mutation Testing'
+      run: './gradlew pitest'
     - id: 'step-4'
-      name: 'Upload Kover Reports'
+      name: 'Upload Mutation Report'
       uses: 'actions/upload-artifact@v4'
       with:
-        name: 'coverage-reports'
-        path: 'app/build/reports/kover'
+        name: 'mutation-report'
+        path: 'app/build/reports/pitest'
     - id: 'step-5'
-      name: 'Calculate Coverage'
+      name: 'Calculate Mutation Score'
       run: |-
-        COVERAGE=$(./gradlew -q printLineCoverage)
-        echo "Raw Coverage: $COVERAGE"
-        COVERAGE=$(printf "%.0f" "$COVERAGE")  # Round to integer
-        echo "Rounded Coverage: $COVERAGE"
-        echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+        SCORE=$(./gradlew -q printMutationScore)
+        echo "Raw Mutation Score: $SCORE"
+        SCORE=$(printf "%.0f" "$SCORE")  # Round to integer
+        echo "Rounded Mutation Score: $SCORE"
+        echo "MUTATION_SCORE=$SCORE" >> $GITHUB_ENV
     - id: 'step-6'
       name: 'Update GitHub Summary'
       run: |-
-        echo "## Code Coverage Report" >> $GITHUB_STEP_SUMMARY
-        echo "**Total Coverage:** $COVERAGE%" >> $GITHUB_STEP_SUMMARY
+        echo "## Mutation Testing Report" >> $GITHUB_STEP_SUMMARY
+        echo "**Mutation Score:** $MUTATION_SCORE%" >> $GITHUB_STEP_SUMMARY
     - id: 'step-7'
-      name: 'Generate Coverage Badge'
+      name: 'Generate Mutation Badge'
       run: |-
         mkdir -p badge
         COLOR=$(
-          if [ "$COVERAGE" -ge 90 ]; then
+          if [ "$MUTATION_SCORE" -ge 80 ]; then
             echo "brightgreen"
-          elif [ "$COVERAGE" -ge 70 ]; then
+          elif [ "$MUTATION_SCORE" -ge 60 ]; then
             echo "yellow"
           else
             echo "red"
           fi
         )
-        URL="https://img.shields.io/badge/Coverage-$COVERAGE%25-$COLOR"
-        curl -sS "$URL" -o badge/coverage-badge.svg
+        URL="https://img.shields.io/badge/Mutation%20Score-$MUTATION_SCORE%25-$COLOR"
+        curl -sS "$URL" -o badge/mutation-badge.svg
     - id: 'step-8'
       name: 'Deploy Badge to GitHub Pages'
       uses: 'peaceiris/actions-gh-pages@v4'

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -82,7 +82,9 @@ jobs:
           fi
         )
         URL="https://img.shields.io/badge/Test%20Strength-$TEST_STRENGTH%25-$COLOR"
-        curl -sS "$URL" -o badge/test-strength-badge.svg
+        # -f so an outage at shields.io fails the job instead of publishing its error page as
+        # the badge, which plain -sS would do while still exiting 0.
+        curl -fsS --retry 3 --retry-all-errors "$URL" -o badge/test-strength-badge.svg
     - id: 'step-8'
       name: 'Deploy Badge to GitHub Pages'
       uses: 'peaceiris/actions-gh-pages@v4'

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -4,9 +4,8 @@
 
 name: 'Mutation Testing'
 on:
-  push:
-    branches:
-    - 'main'
+  schedule:
+  - cron: '0 5 * * 1'
   workflow_dispatch: {}
 concurrency:
   group: 'gh-pages-badges'
@@ -51,6 +50,7 @@ jobs:
       with:
         name: 'mutation-report'
         path: 'app/build/reports/pitest'
+      if: 'always()'
     - id: 'step-5'
       name: 'Calculate Test Strength'
       run: |-
@@ -82,7 +82,7 @@ jobs:
           fi
         )
         URL="https://img.shields.io/badge/Test%20Strength-$TEST_STRENGTH%25-$COLOR"
-        curl -sS "$URL" -o badge/mutation-badge.svg
+        curl -sS "$URL" -o badge/test-strength-badge.svg
     - id: 'step-8'
       name: 'Deploy Badge to GitHub Pages'
       uses: 'peaceiris/actions-gh-pages@v4'

--- a/.github/workflows/mutation-testing.yaml
+++ b/.github/workflows/mutation-testing.yaml
@@ -52,32 +52,36 @@ jobs:
         name: 'mutation-report'
         path: 'app/build/reports/pitest'
     - id: 'step-5'
-      name: 'Calculate Mutation Score'
+      name: 'Calculate Test Strength'
       run: |-
+        STRENGTH=$(./gradlew -q printTestStrength)
         SCORE=$(./gradlew -q printMutationScore)
-        echo "Raw Mutation Score: $SCORE"
-        SCORE=$(printf "%.0f" "$SCORE")  # Round to integer
-        echo "Rounded Mutation Score: $SCORE"
+        echo "Raw Test Strength: $STRENGTH, Raw Mutation Score: $SCORE"
+        STRENGTH=$(printf "%.0f" "$STRENGTH")  # Round to integer
+        SCORE=$(printf "%.0f" "$SCORE")
+        echo "Rounded Test Strength: $STRENGTH, Rounded Mutation Score: $SCORE"
+        echo "TEST_STRENGTH=$STRENGTH" >> $GITHUB_ENV
         echo "MUTATION_SCORE=$SCORE" >> $GITHUB_ENV
     - id: 'step-6'
       name: 'Update GitHub Summary'
       run: |-
         echo "## Mutation Testing Report" >> $GITHUB_STEP_SUMMARY
-        echo "**Mutation Score:** $MUTATION_SCORE%" >> $GITHUB_STEP_SUMMARY
+        echo "**Test Strength:** $TEST_STRENGTH% (of the mutants a test ran, how many it caught)" >> $GITHUB_STEP_SUMMARY
+        echo "**Mutation Score:** $MUTATION_SCORE% (of every mutant, including code no test reaches)" >> $GITHUB_STEP_SUMMARY
     - id: 'step-7'
-      name: 'Generate Mutation Badge'
+      name: 'Generate Test Strength Badge'
       run: |-
         mkdir -p badge
         COLOR=$(
-          if [ "$MUTATION_SCORE" -ge 80 ]; then
+          if [ "$TEST_STRENGTH" -ge 80 ]; then
             echo "brightgreen"
-          elif [ "$MUTATION_SCORE" -ge 60 ]; then
+          elif [ "$TEST_STRENGTH" -ge 60 ]; then
             echo "yellow"
           else
             echo "red"
           fi
         )
-        URL="https://img.shields.io/badge/Mutation%20Score-$MUTATION_SCORE%25-$COLOR"
+        URL="https://img.shields.io/badge/Test%20Strength-$TEST_STRENGTH%25-$COLOR"
         curl -sS "$URL" -o badge/mutation-badge.svg
     - id: 'step-8'
       name: 'Deploy Badge to GitHub Pages'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![GitHub All Releases](https://img.shields.io/github/downloads/LeoColman/Petals/total?label=Downloads%20All%20Time%20(GitHub))](https://github.com/LeoColman/Petals/releases)
 [![GitHub Release Downloads](https://img.shields.io/github/downloads/LeoColman/Petals/latest/total?label=Downloads%20Latest%20Release%20(GitHub))](https://github.com/LeoColman/Petals/releases/latest)
 [![Coverage](https://leocolman.github.io/Petals/coverage-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/kover.yaml)
-[![Test Strength](https://leocolman.github.io/Petals/mutation-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/mutation-testing.yaml)
+[![Test Strength](https://leocolman.github.io/Petals/test-strength-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/mutation-testing.yaml)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026)
 [![Alternatives](https://img.shields.io/badge/Alternative.to-6-blue)](https://alternativeto.net/software/petals-app/)
 
@@ -90,14 +90,14 @@ as follows:
 
 ## Quality
 
-Two numbers are tracked on every push to `main`, and both badges above link to the workflow that
-produces them.
+Both badges above link to the workflow that produces them. Coverage is measured on every push to
+`main`; mutation testing runs weekly, or on demand from the Actions tab.
 
 ### Coverage
 
 [Kover](https://github.com/Kotlin/kotlinx-kover) measures line coverage of the JVM unit tests.
-Composables, generated SQLDelight code and `BuildConfig` are excluded, since none of them are
-exercised by unit tests.
+Composables, generated SQLDelight code, `BuildConfig` and library code Kotlin inlined into our
+classes are excluded, since none of them are exercised by unit tests or ours to test.
 
 - `./gradlew koverHtmlReport` writes a browsable report to `app/build/reports/kover/html`
 - `./gradlew printLineCoverage` prints the single number the badge is built from
@@ -121,7 +121,11 @@ that gap is what the Coverage badge next to it already measures. A low mutation 
 test strength means untested code; a low test strength means the tests that exist do not assert
 enough.
 
-The full run takes several minutes, so it is not part of the pull request checks.
+A full run takes around 13 minutes, so it is scheduled weekly rather than run per merge, and is
+never part of the pull request checks.
+
+Specs must be named `*Test`: PIT is pointed at that glob, and a spec named anything else would be
+skipped without failing anything. `verifySpecNaming` enforces it as part of the `pitest` task.
 
 ## Git Secrets
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 [![IzzyOnDroid Release](https://img.shields.io/endpoint?url=https://apt.izzysoft.de/fdroid/api/v1/shield/br.com.colman.petals)](https://apt.izzysoft.de/fdroid/index/apk/br.com.colman.petals)
 [![GitHub All Releases](https://img.shields.io/github/downloads/LeoColman/Petals/total?label=Downloads%20All%20Time%20(GitHub))](https://github.com/LeoColman/Petals/releases)
 [![GitHub Release Downloads](https://img.shields.io/github/downloads/LeoColman/Petals/latest/total?label=Downloads%20Latest%20Release%20(GitHub))](https://github.com/LeoColman/Petals/releases/latest)
-![Coverage](https://leocolman.github.io/Petals/coverage-badge.svg)
+[![Coverage](https://leocolman.github.io/Petals/coverage-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/kover.yaml)
+[![Mutation Score](https://leocolman.github.io/Petals/mutation-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/mutation-testing.yaml)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026)
 [![Alternatives](https://img.shields.io/badge/Alternative.to-6-blue)](https://alternativeto.net/software/petals-app/)
 
@@ -86,6 +87,34 @@ as follows:
 - F-Droid: `./gradlew assembleFdroidRelease`
 - PlayStore: `./gradlew assemblePlaystoreRelease`
 - GitHub: `./gradlew assembleGithubRelease`
+
+## Quality
+
+Two numbers are tracked on every push to `main`, and both badges above link to the workflow that
+produces them.
+
+### Coverage
+
+[Kover](https://github.com/Kotlin/kotlinx-kover) measures line coverage of the JVM unit tests.
+Composables, generated SQLDelight code and `BuildConfig` are excluded, since none of them are
+exercised by unit tests.
+
+- `./gradlew koverHtmlReport` writes a browsable report to `app/build/reports/kover/html`
+- `./gradlew printLineCoverage` prints the single number the badge is built from
+
+### Mutation Testing
+
+Coverage says a line ran; it does not say a test would notice if the line were wrong.
+[PIT](https://pitest.org) answers that by changing the compiled bytecode and checking whether the
+suite fails. A surviving mutant is a line no assertion cares about.
+
+PIT runs the Kotest engine directly through `kotest-extensions-pitest` and is scoped to the
+`fdroidDebug` variant, with the same exclusions Kover uses.
+
+- `./gradlew pitest` writes a report to `app/build/reports/pitest/index.html`
+- `./gradlew printMutationScore` prints the single number the badge is built from
+
+The full run takes several minutes, so it is not part of the pull request checks.
 
 ## Git Secrets
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![GitHub All Releases](https://img.shields.io/github/downloads/LeoColman/Petals/total?label=Downloads%20All%20Time%20(GitHub))](https://github.com/LeoColman/Petals/releases)
 [![GitHub Release Downloads](https://img.shields.io/github/downloads/LeoColman/Petals/latest/total?label=Downloads%20Latest%20Release%20(GitHub))](https://github.com/LeoColman/Petals/releases/latest)
 [![Coverage](https://leocolman.github.io/Petals/coverage-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/kover.yaml)
-[![Mutation Score](https://leocolman.github.io/Petals/mutation-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/mutation-testing.yaml)
+[![Test Strength](https://leocolman.github.io/Petals/mutation-badge.svg)](https://github.com/LeoColman/Petals/actions/workflows/mutation-testing.yaml)
 ![Maintenance](https://img.shields.io/maintenance/yes/2026)
 [![Alternatives](https://img.shields.io/badge/Alternative.to-6-blue)](https://alternativeto.net/software/petals-app/)
 
@@ -112,7 +112,14 @@ PIT runs the Kotest engine directly through `kotest-extensions-pitest` and is sc
 `fdroidDebug` variant, with the same exclusions Kover uses.
 
 - `./gradlew pitest` writes a report to `app/build/reports/pitest/index.html`
-- `./gradlew printMutationScore` prints the single number the badge is built from
+- `./gradlew printTestStrength` prints the single number the badge is built from
+- `./gradlew printMutationScore` prints the same thing counting untested code too
+
+The badge reports **test strength**, not the raw mutation score: of the mutants a test actually
+executed, how many did it catch. Mutants in code no test reaches are left out on purpose, because
+that gap is what the Coverage badge next to it already measures. A low mutation score beside a high
+test strength means untested code; a low test strength means the tests that exist do not assert
+enough.
 
 The full run takes several minutes, so it is not part of the pull request checks.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -258,7 +258,9 @@ kover {
         annotatedBy("androidx.compose.runtime.Composable")
         classes("*ComposableSingletons*")
         classes("*DatabaseImpl*")
+        classes("*Queries*")
         classes("*BuildConfig*")
+        classes("*\$inlined\$*")
       }
     }
   }
@@ -392,7 +394,11 @@ val mutationVariantCapitalized = mutationVariant.replaceFirstChar { it.uppercase
 val mutationExcludedClasses = listOf(
   "*ComposableSingletons*",
   "*DatabaseImpl*",
+  "*Queries*",
   "*BuildConfig*",
+  // Kotlin inlines library code into our classes, and PIT happily mutates it. Every mutant in
+  // these synthetic classes comes from kotlinx or Koin sources, never from ours.
+  "*\$inlined\$*",
 )
 
 tasks.register<JavaExec>("pitest") {
@@ -455,25 +461,49 @@ tasks.register<JavaExec>("pitest") {
 }
 
 /**
- * Parse the PIT report for badge creation
+ * Number of mutants PIT detected, how many a test actually executed, and how many exist at all.
+ */
+fun readMutationTotals(): Triple<Int, Int, Int> {
+  val report = file("${layout.buildDirectory.get()}/reports/pitest/mutations.xml")
+  val mutations = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(report)
+    .getElementsByTagName("mutation")
+
+  var detected = 0
+  var withoutCoverage = 0
+  for (index in 0 until mutations.length) {
+    val attributes = mutations.item(index).attributes
+    if (attributes.getNamedItem("detected").textContent == "true") detected++
+    if (attributes.getNamedItem("status").textContent == "NO_COVERAGE") withoutCoverage++
+  }
+
+  return Triple(detected, mutations.length - withoutCoverage, mutations.length)
+}
+
+/**
+ * Share of mutants a test both executed and noticed. Unlike the raw mutation score this ignores
+ * code no test reaches, which Kover already reports, so it answers the one question coverage
+ * cannot: when a test does run this line, would it complain if the line were wrong?
+ *
+ * This is the same number PIT prints as "Test strength" in its console summary.
+ */
+tasks.register("printTestStrength") {
+  group = "verification"
+  dependsOn("pitest")
+  doLast {
+    val (detected, covered, _) = readMutationTotals()
+    println("%.1f".format(if (covered == 0) 0.0 else (detected * 100.0) / covered))
+  }
+}
+
+/**
+ * Share of all mutants that were detected. Reported alongside the badge for context: a low score
+ * next to a high test strength means untested code, not weak assertions.
  */
 tasks.register("printMutationScore") {
   group = "verification"
   dependsOn("pitest")
   doLast {
-    val report = file("${layout.buildDirectory.get()}/reports/pitest/mutations.xml")
-
-    val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(report)
-    val mutations = doc.getElementsByTagName("mutation")
-
-    var total = 0
-    var detected = 0
-    for (index in 0 until mutations.length) {
-      total++
-      if (mutations.item(index).attributes.getNamedItem("detected").textContent == "true") detected++
-    }
-
-    val score = if (total == 0) 0.0 else (detected * 100.0) / total
-    println("%.1f".format(score))
+    val (detected, _, total) = readMutationTotals()
+    println("%.1f".format(if (total == 0) 0.0 else (detected * 100.0) / total))
   }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,7 +146,21 @@ android {
 
 }
 
+/**
+ * Classpath used to launch PIT. Kept apart from the app's own configurations so that the mutation
+ * engine never leaks into the shipped artifact.
+ */
+val pitest: Configuration by configurations.creating {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
 dependencies {
+  // PIT (mutation testing). Kotest ships its own PIT test plugin, so PIT drives the
+  // Kotest engine directly instead of going through the JUnit Platform.
+  pitest(libs.pitest.command.line)
+  pitest(libs.kotest.pitest)
+
   // Kotlin
   testRuntimeOnly(libs.kotlin.reflect)
   testImplementation(libs.kotlinx.coroutines.test)
@@ -358,5 +372,108 @@ tasks.register("printLineCoverage") {
     }
 
     println("%.1f".format(coveragePercent))
+  }
+}
+
+/**
+ * Mutation testing.
+ *
+ * PIT has no maintained Android Gradle plugin (the community one is pinned to AGP 7), so PIT is
+ * invoked straight from its command line entrypoint. Everything it needs is derived from the
+ * `fdroidDebug` unit test task, which is the flavour with no proprietary dependencies.
+ */
+val mutationVariant = "fdroidDebug"
+val mutationVariantCapitalized = mutationVariant.replaceFirstChar { it.uppercase() }
+
+/**
+ * Same exclusions as the `kover` block above, so both numbers describe the same code. Composables
+ * are dropped through PIT's `fann` feature, which filters anything carrying the given annotation.
+ */
+val mutationExcludedClasses = listOf(
+  "*ComposableSingletons*",
+  "*DatabaseImpl*",
+  "*BuildConfig*",
+)
+
+tasks.register<JavaExec>("pitest") {
+  group = "verification"
+  description = "Runs PIT mutation testing against the $mutationVariant variant"
+
+  val unitTest = tasks.named<Test>("test${mutationVariantCapitalized}UnitTest")
+  dependsOn(unitTest)
+
+  val mutableCodePaths = files(
+    layout.buildDirectory.dir("tmp/kotlin-classes/$mutationVariant"),
+    layout.buildDirectory.dir("intermediates/javac/$mutationVariant/classes"),
+  )
+  val reportDir = layout.buildDirectory.dir("reports/pitest")
+  val classpathFile = layout.buildDirectory.file("tmp/pitest/classpath.txt")
+  val sourceDirs = files("src/main/kotlin", "src/main/java")
+
+  mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
+
+  // PIT hands its own launch classpath down to the minions, and the Kotest PIT plugin drags in
+  // older Byte Buddy / coroutines than the app tests are compiled against. Putting the unit test
+  // runtime first means the minions load exactly the jars `testFdroidDebugUnitTest` loads.
+  classpath(unitTest.map { it.classpath })
+  classpath(pitest)
+
+  // PIT reads the classpath from a file because the flattened Android test classpath is far
+  // longer than a command line can hold.
+  doFirst {
+    val entries = mutableCodePaths + unitTest.get().testClassesDirs + unitTest.get().classpath
+    classpathFile.get().asFile.apply {
+      parentFile.mkdirs()
+      writeText(entries.filter { it.exists() }.joinToString("\n") { it.absolutePath })
+    }
+  }
+
+  argumentProviders.add(
+    CommandLineArgumentProvider {
+      listOf(
+        "--classPathFile=${classpathFile.get().asFile.absolutePath}",
+        "--mutableCodePaths=${mutableCodePaths.joinToString(",") { it.absolutePath }}",
+        "--sourceDirs=${sourceDirs.joinToString(",") { it.absolutePath }}",
+        "--reportDir=${reportDir.get().asFile.absolutePath}",
+        "--targetClasses=br.com.colman.petals.*",
+        // Specs only. A wider glob makes PIT offer every Android class to the Kotest engine as a
+        // candidate test, and instantiating those outside a device hangs the run.
+        "--targetTests=br.com.colman.petals.*Test",
+        "--excludedClasses=${mutationExcludedClasses.joinToString(",")}",
+        "--features=+fann(annotation[Composable])",
+        "--testPlugin=Kotest",
+        // Property based specs are slow enough that PIT's 4s default kills healthy minions.
+        "--timeoutConst=10000",
+        "--jvmArgs=-Dkotest.framework.config.fqn=br.com.colman.petals.KotestConfig",
+        "--outputFormats=HTML,XML",
+        "--timestampedReports=false",
+        "--failWhenNoMutations=false",
+        "--threads=${Runtime.getRuntime().availableProcessors()}",
+      )
+    }
+  )
+}
+
+/**
+ * Parse the PIT report for badge creation
+ */
+tasks.register("printMutationScore") {
+  group = "verification"
+  dependsOn("pitest")
+  doLast {
+    val report = file("${layout.buildDirectory.get()}/reports/pitest/mutations.xml")
+
+    val doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(report)
+    val mutations = doc.getElementsByTagName("mutation")
+
+    var total = 0
+    var detected = 0
+    for (index in 0 until mutations.length) {
+      total++
+      if (mutations.item(index).attributes.getNamedItem("detected").textContent == "true") detected++
+    }
+
+    val score = if (total == 0) 0.0 else (detected * 100.0) / total
+    println("%.1f".format(score))
   }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -151,7 +151,7 @@ android {
  * Classpath used to launch PIT. Kept apart from the app's own configurations so that the mutation
  * engine never leaks into the shipped artifact.
  */
-val pitest: Configuration by configurations.creating {
+val pitest = configurations.create("pitest") {
   isCanBeConsumed = false
   isCanBeResolved = true
 }
@@ -411,6 +411,10 @@ val mutationExcludedClasses = listOf(
  * to the engine. Its mutants are then reported as NO_COVERAGE, which drags the mutation score down
  * but leaves test strength — the number on the badge — completely unmoved. The badge cannot show
  * this mistake, so fail loudly instead.
+ *
+ * This reads source rather than bytecode, so it only recognises specs that name one of Kotest's
+ * own styles as their supertype. A spec extending a project-specific base class would still slip
+ * through; there is no such base class today.
  */
 val verifySpecNaming = tasks.register("verifySpecNaming") {
   group = "verification"
@@ -420,9 +424,10 @@ val verifySpecNaming = tasks.register("verifySpecNaming") {
   inputs.files(testSources).withPropertyName("testSources")
 
   doLast {
+    // `(?:\w+\s+)*` so that `internal class`, `private class` and friends are caught too.
     val specDeclaration = Regex(
-      """^class\s+(\w+)\s*:\s*(FunSpec|StringSpec|ShouldSpec|DescribeSpec|BehaviorSpec|FreeSpec""" +
-        """|WordSpec|ExpectSpec|FeatureSpec|AnnotationSpec)\b""",
+      """^(?:\w+\s+)*class\s+(\w+)\s*:\s*(FunSpec|StringSpec|ShouldSpec|DescribeSpec|BehaviorSpec""" +
+        """|FreeSpec|WordSpec|ExpectSpec|FeatureSpec|AnnotationSpec)\b""",
       RegexOption.MULTILINE
     )
 
@@ -519,12 +524,15 @@ tasks.register<JavaExec>("pitest") {
  */
 fun readMutationTotals(): Triple<Int, Int, Int> {
   val report = file("${layout.buildDirectory.get()}/reports/pitest/mutations.xml")
-  // PIT runs with --failWhenNoMutations=false, so a run that mutates nothing is a success that
-  // writes no report. Report zeroes rather than failing the badge step with a stack trace.
-  if (!report.exists()) return Triple(0, 0, 0)
+  // Missing or empty means PIT produced nothing, not that every mutant survived. Publishing 0%
+  // for that would be indistinguishable from a genuinely terrible suite, so refuse to guess.
+  if (!report.exists()) {
+    throw GradleException("PIT wrote no report at $report. Run `./gradlew pitest` first.")
+  }
 
   val mutations = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(report)
     .getElementsByTagName("mutation")
+  if (mutations.length == 0) throw GradleException("PIT generated no mutants; $report is empty.")
 
   var detected = 0
   var withoutCoverage = 0

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import java.util.Locale
 import java.util.Properties
 import javax.xml.parsers.DocumentBuilderFactory
 import org.gradle.api.JavaVersion.VERSION_17
@@ -373,7 +374,9 @@ tasks.register("printLineCoverage") {
       childNode = childNode.nextSibling
     }
 
-    println("%.1f".format(coveragePercent))
+    // Locale.US because the workflow feeds this straight into `printf "%.0f"`, which rejects the
+    // comma separator a machine set to, say, pt_BR would otherwise produce.
+    println("%.1f".format(Locale.US, coveragePercent))
   }
 }
 
@@ -516,6 +519,10 @@ tasks.register<JavaExec>("pitest") {
  */
 fun readMutationTotals(): Triple<Int, Int, Int> {
   val report = file("${layout.buildDirectory.get()}/reports/pitest/mutations.xml")
+  // PIT runs with --failWhenNoMutations=false, so a run that mutates nothing is a success that
+  // writes no report. Report zeroes rather than failing the badge step with a stack trace.
+  if (!report.exists()) return Triple(0, 0, 0)
+
   val mutations = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(report)
     .getElementsByTagName("mutation")
 
@@ -542,7 +549,7 @@ tasks.register("printTestStrength") {
   dependsOn("pitest")
   doLast {
     val (detected, covered, _) = readMutationTotals()
-    println("%.1f".format(if (covered == 0) 0.0 else (detected * 100.0) / covered))
+    println("%.1f".format(Locale.US, if (covered == 0) 0.0 else (detected * 100.0) / covered))
   }
 }
 
@@ -555,6 +562,6 @@ tasks.register("printMutationScore") {
   dependsOn("pitest")
   doLast {
     val (detected, _, total) = readMutationTotals()
-    println("%.1f".format(if (total == 0) 0.0 else (detected * 100.0) / total))
+    println("%.1f".format(Locale.US, if (total == 0) 0.0 else (detected * 100.0) / total))
   }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -396,17 +396,53 @@ val mutationExcludedClasses = listOf(
   "*DatabaseImpl*",
   "*Queries*",
   "*BuildConfig*",
-  // Kotlin inlines library code into our classes, and PIT happily mutates it. Every mutant in
-  // these synthetic classes comes from kotlinx or Koin sources, never from ours.
+  // Kotlin inlines library code into our classes, and PIT happily mutates it. Verified against the
+  // report: of the 513 mutants in these synthetic classes, none came from a file under src/main —
+  // they were all Emitters.kt, SafeCollector.common.kt, Koin or the stdlib. That is a measurement,
+  // not a guarantee: an `inline fun` of our own taking a lambda would land here too.
   "*\$inlined\$*",
 )
+
+/**
+ * PIT's `--targetTests` glob matches `*Test`, so a spec class named anything else is never handed
+ * to the engine. Its mutants are then reported as NO_COVERAGE, which drags the mutation score down
+ * but leaves test strength — the number on the badge — completely unmoved. The badge cannot show
+ * this mistake, so fail loudly instead.
+ */
+val verifySpecNaming = tasks.register("verifySpecNaming") {
+  group = "verification"
+  description = "Fails if a Kotest spec is named so that mutation testing would silently skip it"
+
+  val testSources = fileTree("src/test/kotlin") { include("**/*.kt") }
+  inputs.files(testSources).withPropertyName("testSources")
+
+  doLast {
+    val specDeclaration = Regex(
+      """^class\s+(\w+)\s*:\s*(FunSpec|StringSpec|ShouldSpec|DescribeSpec|BehaviorSpec|FreeSpec""" +
+        """|WordSpec|ExpectSpec|FeatureSpec|AnnotationSpec)\b""",
+      RegexOption.MULTILINE
+    )
+
+    val misnamed = testSources.files.flatMap { source ->
+      specDeclaration.findAll(source.readText())
+        .map { it.groupValues[1] }
+        .filterNot { it.endsWith("Test") }
+    }
+
+    if (misnamed.isNotEmpty()) {
+      throw GradleException(
+        "Kotest specs must be named *Test or PIT silently skips them: ${misnamed.joinToString()}"
+      )
+    }
+  }
+}
 
 tasks.register<JavaExec>("pitest") {
   group = "verification"
   description = "Runs PIT mutation testing against the $mutationVariant variant"
 
   val unitTest = tasks.named<Test>("test${mutationVariantCapitalized}UnitTest")
-  dependsOn(unitTest)
+  dependsOn(unitTest, verifySpecNaming)
 
   val mutableCodePaths = files(
     layout.buildDirectory.dir("tmp/kotlin-classes/$mutationVariant"),
@@ -416,6 +452,22 @@ tasks.register<JavaExec>("pitest") {
   val classpathFile = layout.buildDirectory.file("tmp/pitest/classpath.txt")
   val sourceDirs = files("src/main/kotlin", "src/main/java")
 
+  // Everything PIT needs on the classpath of the code under test, in one lazy collection so that
+  // nothing has to reach back into the test task while the build is running.
+  val codeUnderTest = files(
+    mutableCodePaths,
+    unitTest.map { it.testClassesDirs },
+    unitTest.map { it.classpath },
+  )
+
+  // Declaring inputs and outputs is what lets Gradle skip this task on the follow-up
+  // `printTestStrength` and `printMutationScore` invocations. Without them PIT is never
+  // up-to-date, so it reruns on every invocation: three full runs per CI job, each producing a
+  // different report, and PIT's console output leaking into `$(./gradlew -q ...)`.
+  inputs.files(codeUnderTest).withPropertyName("codeUnderTest")
+  inputs.files(sourceDirs).withPropertyName("sourceDirs")
+  outputs.dir(reportDir).withPropertyName("report")
+
   mainClass.set("org.pitest.mutationtest.commandline.MutationCoverageReport")
 
   // PIT hands its own launch classpath down to the minions, and the Kotest PIT plugin drags in
@@ -424,40 +476,39 @@ tasks.register<JavaExec>("pitest") {
   classpath(unitTest.map { it.classpath })
   classpath(pitest)
 
-  // PIT reads the classpath from a file because the flattened Android test classpath is far
-  // longer than a command line can hold.
+  args(
+    "--classPathFile=${classpathFile.get().asFile.absolutePath}",
+    "--mutableCodePaths=${mutableCodePaths.joinToString(",") { it.absolutePath }}",
+    "--sourceDirs=${sourceDirs.joinToString(",") { it.absolutePath }}",
+    "--reportDir=${reportDir.get().asFile.absolutePath}",
+    "--targetClasses=br.com.colman.petals.*",
+    // Specs only. A wider glob makes PIT offer every Android class to the Kotest engine as a
+    // candidate test, and instantiating those outside a device hangs the run. `verifySpecNaming`
+    // guards the convention this relies on.
+    "--targetTests=br.com.colman.petals.*Test",
+    "--excludedClasses=${mutationExcludedClasses.joinToString(",")}",
+    "--features=+fann(annotation[Composable])",
+    "--testPlugin=Kotest",
+    // Property based specs are slow enough that PIT's 4s default kills healthy minions.
+    "--timeoutConst=10000",
+    "--jvmArgs=-Dkotest.framework.config.fqn=br.com.colman.petals.KotestConfig",
+    "--outputFormats=HTML,XML",
+    "--timestampedReports=false",
+    "--failWhenNoMutations=false",
+  )
+
   doFirst {
-    val entries = mutableCodePaths + unitTest.get().testClassesDirs + unitTest.get().classpath
+    // PIT reads the classpath from a file because the flattened Android test classpath is far
+    // longer than a command line can hold.
     classpathFile.get().asFile.apply {
       parentFile.mkdirs()
-      writeText(entries.filter { it.exists() }.joinToString("\n") { it.absolutePath })
+      writeText(codeUnderTest.filter { it.exists() }.joinToString("\n") { it.absolutePath })
     }
-  }
 
-  argumentProviders.add(
-    CommandLineArgumentProvider {
-      listOf(
-        "--classPathFile=${classpathFile.get().asFile.absolutePath}",
-        "--mutableCodePaths=${mutableCodePaths.joinToString(",") { it.absolutePath }}",
-        "--sourceDirs=${sourceDirs.joinToString(",") { it.absolutePath }}",
-        "--reportDir=${reportDir.get().asFile.absolutePath}",
-        "--targetClasses=br.com.colman.petals.*",
-        // Specs only. A wider glob makes PIT offer every Android class to the Kotest engine as a
-        // candidate test, and instantiating those outside a device hangs the run.
-        "--targetTests=br.com.colman.petals.*Test",
-        "--excludedClasses=${mutationExcludedClasses.joinToString(",")}",
-        "--features=+fann(annotation[Composable])",
-        "--testPlugin=Kotest",
-        // Property based specs are slow enough that PIT's 4s default kills healthy minions.
-        "--timeoutConst=10000",
-        "--jvmArgs=-Dkotest.framework.config.fqn=br.com.colman.petals.KotestConfig",
-        "--outputFormats=HTML,XML",
-        "--timestampedReports=false",
-        "--failWhenNoMutations=false",
-        "--threads=${Runtime.getRuntime().availableProcessors()}",
-      )
-    }
-  )
+    // Added here rather than above so the core count of whichever machine runs the build stays out
+    // of the task's input fingerprint.
+    args("--threads=${Runtime.getRuntime().availableProcessors()}")
+  }
 }
 
 /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ licensee = "1.14.1"
 vanpra-material-dialogs = "0.9.0"
 sqldelight = "2.3.2"
 mockk = "1.14.11"
+pitest = "1.19.1"
 review = "2.0.2"
 work = "2.10.1"
 
@@ -39,6 +40,7 @@ kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest"
 kotest-runner-android = { module = "br.com.colman:kotest-runner-android", version = "1.2.3" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-framework-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest" }
+kotest-pitest = { module = "io.kotest:kotest-extensions-pitest", version.ref = "kotest" }
 kotlin-csv = "com.jsoizo:kotlin-csv:1.11.0"
 kotlin-date-range = "me.moallemi.tools:kotlin-date-range:1.0.0"
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
@@ -47,6 +49,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 mockk-agent = { module = "io.mockk:mockk-agent", version.ref = "mockk" }
 mp-android-chart = "com.github.AppDevNext:AndroidChart:3.1.0.31"
+pitest-command-line = { module = "org.pitest:pitest-command-line", version.ref = "pitest" }
 snodge = "com.natpryce:snodge:3.7.0.0"
 sqldelight-sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 timber = "com.jakewharton.timber:timber:5.0.1"


### PR DESCRIPTION
## What

Coverage says a line ran; it does not say a test would notice if the line were wrong. This adds [PIT](https://pitest.org) to answer the second question, and a badge next to the existing Coverage one.

- `./gradlew pitest` writes `app/build/reports/pitest/index.html`
- `./gradlew printTestStrength` prints the number the badge is built from
- `./gradlew printMutationScore` prints the same thing counting untested code too

The badge reports **test strength: 61.2%** — of the mutants a test actually executed, how many it caught. The raw mutation score on the same run is 23.4%, and that difference is the point: 986 of 1597 mutants live in code no unit test reaches. That gap is what the Coverage badge beside it already measures, so reporting it twice said nothing new. Both numbers go into the workflow summary, since they only mean something side by side.

| package | killed | survived | no coverage |
|---|---:|---:|---:|
| `.use.io.output.auto` | 74 | 36 | 33 |
| `.use.repository` | 78 | 59 | 90 |
| `.hittimer` | 42 | 19 | 97 |
| `.settings` | 92 | 177 | 224 |
| `.use` | 0 | 0 | 241 |
| `.navigation` | 0 | 0 | 90 |

## Design notes

**PIT is invoked from its command line entrypoint, not a Gradle plugin.** The only Android PIT plugin (`pl.droidsonroids.pitest`) has been unmaintained since 2022 and is compiled against AGP 7.3.1; this project is on AGP 9.2.1. A `JavaExec` task deriving everything from `testFdroidDebugUnitTest` has no such version coupling.

**The unit test runtime classpath goes ahead of PIT's own jars.** PIT hands its launch classpath down to the minions, and `kotest-extensions-pitest` pulls `kotlinx-coroutines-debug`, which pins Byte Buddy 1.10.9 and coroutines 1.10.2. Those shadowed MockK's 1.18.2 and the app's 1.11.0, so every mock failed to instrument (`Unsupported class file major version 61`) and every `runBlocking` threw `NoSuchMethodError: BuildersKt.runBlockingK$default`. Ordering the test runtime first means the minions load exactly the jars Gradle loads.

**Kotest drives the tests, not the JUnit Platform.** `kotest-extensions-pitest` registers a `Kotest` test plugin, so PIT runs the engine directly. It needs `kotest.framework.config.fqn` passed through `--jvmArgs`, or the specs run without `KotestConfig` and lose `IsolationMode.InstancePerTest`.

**`--targetTests` is scoped to `*Test`.** A wider glob offered PIT all 1383 classes under `br.com.colman.petals`, including Compose screens and Activities; the Kotest engine then tries to instantiate each one as a candidate spec, which hangs off-device. Scoped to specs it is 98 classes and the coverage phase drops to ~2 minutes.

**Composables are filtered by annotation, not by package.** PIT's `fann` feature drops anything carrying `@Composable`, mirroring the `annotatedBy` exclusion the `kover` block already uses. This alone cut the mutation population from 8585 to 2196.

**Generated and inlined code is excluded from both tools.** `*Queries*` (SQLDelight, same category as the existing `*DatabaseImpl*` filter) and `*$inlined$*` (Kotlin inlines library code into our classes and PIT mutates it). Of the 513 mutants in those synthetic classes, zero trace back to a Petals source file — all `Emitters.kt`, `SafeCollector.common.kt`, Koin and stdlib. 599 mutants removed.

**The Kover workflow no longer orphans the `gh-pages` branch.** Both badges live there now, so `force_orphan` became `keep_files` and the two workflows share a `concurrency` group to serialise their pushes. Mutation testing is scheduled weekly so it never parks the coverage badge behind a 13 minute job.

**`pitest` declares inputs and outputs.** Without them Gradle never treats it as up-to-date, so PIT reran on each of the workflow's three Gradle invocations — three 13 minute runs whose reports disagree, and PIT's console output leaking into `$(./gradlew -q ...)` and breaking the badge value. The follow-up invocations now finish in 659ms.

**`verifySpecNaming` guards the `*Test` convention.** A spec named otherwise is silently skipped by PIT, and because its mutants become NO_COVERAGE the test strength badge cannot reveal it.

## What was deliberately not excluded

Excluding the packages holding Compose UI would take the mutation score from 23% to 47%, but neither tool can express "adjacent to a Composable" — only class globs — and package globs would bury real gaps:

- `statistics/graph/data/DistributionPerDayOfWeek.kt` and `DistributionPerHour.kt` contain no Composable at all. They are gram distribution maths with no unit test, 57 uncovered mutants between them.
- `AutoExportWorker`, 14 uncovered mutants.

Test strength sidesteps this: it sat at 57-61% across every exclusion set tried, because uncovered mutants are out of its denominator by definition.

## Verification

`./gradlew pitest printTestStrength printMutationScore` is green: 1597 mutations, 374 killed, 986 without coverage. The tasks print 61.2 and 23.4, matching the `Test strength 61%` and `23%` in PIT's own console summary. A full run takes ~13 minutes, so it is scheduled weekly (Mondays 05:00 UTC) plus manual dispatch, rather than running per merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RYpQKkQH6anZYSbrK71mF

