### PR TITLE
✅ Pin the minimum-doses boundary in the tolerance model

### DIFF
--- a/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeriesTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/withdrawal/tolerance/DoseSeriesTest.kt
@@ -59,6 +59,14 @@ class DoseSeriesTest : FunSpec({
     result.effective.inDays() shouldBe (4.0 plusOrMinus 1e-4)
   }
 
+  test("Exactly the minimum number of uses is enough to run the model") {
+    // The pair with the test above pins the boundary from both sides. One short of the minimum
+    // falls back; the minimum itself must model, or the threshold has quietly moved by one.
+    val result = estimate(List(MinDosesForModel) { use(daysAgo = it + 1.0, grams = 3.0) })!!
+
+    result.mode shouldBe Grams
+  }
+
   test("An ounce a day cut to an eighth reads as mid withdrawal while the last use was minutes ago") {
     val history = uses(days = 90, perDay = 1, grams = 28.0, endingDaysAgo = 14.0) + uses(14, 1, 3.5)
 


### PR DESCRIPTION
## What

The first mutant found by the mutation testing added in #1112.

`DoseSeries.kt:49` guards the tolerance model with a minimum number of doses:

```kotlin
if (window.size < MinDosesForModel) return null   // MinDosesForModel = 3
```

PIT flips `<` to `<=` and the entire suite stays green. That mutant is a real
behaviour change: a user with exactly three logged uses would silently stop
getting the tolerance-adjusted reading and drop back to plain
time-since-last-use.

## Why nothing caught it

The existing test only approaches the threshold from below:

```kotlin
test("Fewer uses than the minimum falls back to the time since the last use") {
  val result = estimate(listOf(use(5.0, 3.0), use(4.0, 3.0)))!!   // 2 uses
```

Nothing asserted what happens *at* the minimum. The coverage threshold a few
lines further down is already pinned from both sides:

```kotlin
estimate(window(80))!!.mode shouldBe Grams
estimate(window(79))!!.mode shouldBe Sessions
```

and has no surviving mutants as a result. This gives the dose count the same
treatment.

Worth noting that **line coverage could never have found this** — line 49 was
already fully covered by the tests above. Only mutation testing distinguishes
"the line ran" from "a test would notice if the line were wrong".

## The test

```kotlin
test("Exactly the minimum number of uses is enough to run the model") {
  val result = estimate(List(MinDosesForModel) { use(daysAgo = it + 1.0, grams = 3.0) })!!

  result.mode shouldBe Grams
}
```

Written against `MinDosesForModel` rather than a literal `3`, so raising the
constant carries the test with it rather than quietly making it redundant.

## Verification

The mutant dies, and this test is the only thing that kills it:

```
<  MinDosesForModel   BUILD SUCCESSFUL
<= MinDosesForModel   DoseSeriesTest > Exactly the minimum number of uses
                      is enough to run the model FAILED
```

Full unit test suite green. No production code changed.

Effect on the badge is about 0.2 points — one mutant out of 611 covered. It
earns its place by pinning a real off-by-one in the tolerance model, not by
moving the number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RYpQKkQH6anZYSbrK71mF
