### PR TITLE
✅ Pin the pause window edges and equal endpoints

### DIFF
--- a/app/src/test/kotlin/br/com/colman/petals/use/pause/repository/PauseTest.kt
+++ b/app/src/test/kotlin/br/com/colman/petals/use/pause/repository/PauseTest.kt
@@ -29,6 +29,25 @@ class PauseTest : FunSpec({
       pause shouldNotBeActiveAt NOON.minusSeconds(1)
     }
 
+    test("The start and end instants are themselves inside the pause") {
+      // The two tests above only check one second outside each edge, which leaves the edges
+      // themselves free to become exclusive without anything noticing.
+      val pause = Pause(startTime = NOON, endTime = MAX)
+
+      pause shouldBeActiveAt NOON
+      pause shouldBeActiveAt MAX
+    }
+
+    test("A pause that starts and ends together covers only that instant") {
+      // Equal endpoints are the point where "passes through midnight" flips. Read as passing
+      // through midnight, this pause would cover the whole day except this one instant.
+      val pause = Pause(startTime = NOON, endTime = NOON)
+
+      pause shouldBeActiveAt NOON
+      pause shouldNotBeActiveAt NOON.plusSeconds(1)
+      pause shouldNotBeActiveAt NOON.minusSeconds(1)
+    }
+
     test("Pause disabled") {
       val pause = Pause(startTime = MIN, endTime = MAX, isEnabled = false)
       pause shouldNotBeActiveAt NOON


### PR DESCRIPTION
## What

Two more mutants found by the mutation testing from #1112, both in `Pause`, both about instants the existing tests step over rather than land on. No production code changes.

## The window edges are never asserted

`Pause.kt:21` decides membership with a range:

```kotlin
time in startTime..endTime
```

which compiles to two comparisons. Make either one exclusive and the whole suite stays green. The existing tests only probe one second outside each edge:

```kotlin
pause shouldNotBeActiveAt NOON.plusSeconds(1)
pause shouldNotBeActiveAt NOON.minusSeconds(1)
```

Nothing said the boundary instants are themselves inside the pause. In user terms: a pause set to end at 12:00 would stop applying *at* 12:00 rather than after it.

`Full time pause` looks like it should cover this, but it draws from `Arb.localTime()`, so whether it ever lands on `MIN` or `MAX` is chance. It does not catch the single-boundary mutant — which is exactly why PIT reported that mutant as survived.

## Equal endpoints flip the midnight branch

`Pause.kt:14` derives the wrap-around flag:

```kotlin
private val passesThroughMidnight = startTime > endTime
```

Widen to `>=` and a pause whose start equals its end is treated as passing through midnight, so rather than covering a single instant it covers **the entire day except that instant** — an inverted pause. No test used equal endpoints.

## The tests

```kotlin
test("The start and end instants are themselves inside the pause") {
  val pause = Pause(startTime = NOON, endTime = MAX)
  pause shouldBeActiveAt NOON
  pause shouldBeActiveAt MAX
}

test("A pause that starts and ends together covers only that instant") {
  val pause = Pause(startTime = NOON, endTime = NOON)
  pause shouldBeActiveAt NOON
  pause shouldNotBeActiveAt NOON.plusSeconds(1)
  pause shouldNotBeActiveAt NOON.minusSeconds(1)
}
```

## Verification

Each mutant applied by hand, **one boundary at a time**, the way PIT mutates them. My first attempt flipped both range endpoints at once, which matches no real mutant and produced a misleading extra failure; redone properly:

```
time >= startTime && time < endTime   ->  "start and end instants ..."      FAILED
                                          "starts and ends together ..."    FAILED

passesThroughMidnight  >  becomes >=  ->  "starts and ends together ..."    FAILED
```

Repeated across runs to confirm the kills are deterministic rather than the property test's arbitrary times. Production source verified untouched (`git diff app/src/main/` is empty); full unit suite green in 1m10s.

As with #1113, line coverage could not have found either of these: both lines were already fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RYpQKkQH6anZYSbrK71mF
