### PR TITLE
♿ Make toggle rows announce what they toggle (#931)

### DIFF
--- a/app/src/androidTest/kotlin/br/com/colman/petals/settings/view/dialog/SwitchListItemTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/settings/view/dialog/SwitchListItemTest.kt
@@ -1,0 +1,56 @@
+package br.com.colman.petals.settings.view.dialog
+
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.FunSpec
+import br.com.colman.petals.MainActivity
+import compose.icons.TablerIcons
+import compose.icons.tablericons.ToggleLeft
+import io.kotest.matchers.shouldBe
+
+/**
+ * Guards the screen reader contract from #931. The row has to be a single toggleable node carrying
+ * the label, otherwise a screen reader stops twice: once on text with no state, once on a state with
+ * no name. Merely making the row toggleable does not achieve that, because Material's ListItem
+ * merges its own descendants and keeps the label on a node of its own.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SwitchListItemTest : FunSpec({
+
+  test("the row is one toggleable node that names what it toggles") {
+    runAndroidComposeUiTest<MainActivity> {
+      activity!!.setContent {
+        SwitchListItem(TablerIcons.ToggleLeft, Label, Description, false) { }
+      }
+
+      onAllNodes(isToggleable()).fetchSemanticsNodes().size shouldBe 1
+      onAllNodes(hasContentDescription("$Label. $Description") and isToggleable())[0].assertIsOff()
+    }
+  }
+
+  test("tapping the row toggles, not only the switch itself") {
+    runAndroidComposeUiTest<MainActivity> {
+      var state by mutableStateOf(false)
+      activity!!.setContent {
+        SwitchListItem(TablerIcons.ToggleLeft, Label, Description, state) { state = it }
+      }
+
+      onAllNodes(isToggleable())[0].performClick()
+
+      state shouldBe true
+      onAllNodes(isToggleable())[0].assertIsOn()
+    }
+  }
+})
+
+private const val Label = "Milliseconds on hit timer"
+private const val Description = "Enable or disable milliseconds on the hit timer page"

--- a/app/src/androidTest/kotlin/br/com/colman/petals/statistics/component/DaysCheckboxTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/statistics/component/DaysCheckboxTest.kt
@@ -1,0 +1,50 @@
+package br.com.colman.petals.statistics.component
+
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runAndroidComposeUiTest
+import br.com.colman.kotest.FunSpec
+import br.com.colman.petals.MainActivity
+import io.kotest.matchers.shouldBe
+
+/**
+ * The period label used to carry a bare clickable of its own, which gave a screen reader a second
+ * stop with no role and no checked state. Row and label are one target now, and the test tag rides
+ * along with the click handling so it still marks the thing you tap.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DaysCheckboxTest : FunSpec({
+
+  test("the label and the checkbox are one toggleable node") {
+    runAndroidComposeUiTest<MainActivity> {
+      activity!!.setContent {
+        DaysCheckbox(false, { }, Period.Week)
+      }
+
+      onAllNodes(isToggleable()).fetchSemanticsNodes().size shouldBe 1
+      onNodeWithTag("Days 7").assertIsOff()
+    }
+  }
+
+  test("tapping the row toggles through the tagged node") {
+    runAndroidComposeUiTest<MainActivity> {
+      var selected by mutableStateOf(false)
+      activity!!.setContent {
+        DaysCheckbox(selected, { selected = it }, Period.Week)
+      }
+
+      onNodeWithTag("Days 7").performClick()
+
+      selected shouldBe true
+      onNodeWithTag("Days 7").assertIsOn()
+    }
+  }
+})

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
@@ -52,6 +53,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -107,8 +109,15 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
     Column(Modifier.width(180.dp), spacedBy(8.dp)) {
       TimerButtons(hitTimer, millisElapsed, isPaused) { isPaused = it }
 
-      Row(Modifier.fillMaxWidth(), Start, CenterVertically) {
-        Checkbox(shouldVibrate, { repository.setShouldVibrate(it) })
+      // Row rather than the Checkbox owns the toggle, so the label is announced with the state.
+      Row(
+        Modifier
+          .fillMaxWidth()
+          .toggleable(shouldVibrate, role = Role.Checkbox) { repository.setShouldVibrate(it) },
+        Start,
+        CenterVertically
+      ) {
+        Checkbox(shouldVibrate, null)
         Text(stringResource(vibrate_on_timer_end))
       }
     }

--- a/app/src/main/kotlin/br/com/colman/petals/settings/view/dialog/SwitchListItem.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/settings/view/dialog/SwitchListItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.ListItem
@@ -15,6 +16,10 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -26,15 +31,24 @@ fun SwitchListItem(
   initialState: Boolean,
   onChangeState: (Boolean) -> Unit,
 ) {
-  Row {
+  // One focus stop for the whole row. Toggleable alone is not enough: Material's ListItem merges its
+  // own descendants, so the label stays on a node of its own and a screen reader still stops twice,
+  // once for the text and once for a state with no name attached. Clearing the ListItem drops that
+  // second stop, and the description carries the words it was holding. The Switch hands over its
+  // onCheckedChange for the same reason.
+  Row(
+    Modifier
+      .toggleable(value = initialState, role = Role.Switch, onValueChange = onChangeState)
+      .semantics { contentDescription = "$text. $description" }
+  ) {
     ListItem(
-      modifier = Modifier.fillMaxWidth().weight(0.7f),
+      modifier = Modifier.fillMaxWidth().weight(0.7f).clearAndSetSemantics { },
       icon = { Icon(icon, null, Modifier.size(42.dp)) },
       secondaryText = { Text(description) }
     ) {
       Text(text)
     }
-    Switch(initialState, onChangeState, modifier = Modifier.align(CenterVertically).padding(end = 8.dp))
+    Switch(initialState, null, modifier = Modifier.align(CenterVertically).padding(end = 8.dp))
   }
 }
 

--- a/app/src/main/kotlin/br/com/colman/petals/statistics/component/MultiPeriodSelect.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/statistics/component/MultiPeriodSelect.kt
@@ -2,12 +2,12 @@
 
 package br.com.colman.petals.statistics.component
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 
@@ -54,8 +55,17 @@ fun CheckboxPreviews() {
 
 @Composable
 fun DaysCheckbox(selected: Boolean, setSelected: (Boolean) -> Unit, period: Period) {
-  Row(Modifier, Arrangement.Start, Alignment.CenterVertically) {
-    Checkbox(selected, setSelected, Modifier.testTag("Days ${period.days}"))
-    Text(period.label(), Modifier.clickable { setSelected(!selected) }, fontSize = 10.sp)
+  // The tag moves to the row along with the click handling, so it still marks the thing you tap.
+  // The label used to carry its own bare clickable, which gave a screen reader a second stop with
+  // no role and no checked state; folding both into the row leaves exactly one target.
+  Row(
+    Modifier
+      .testTag("Days ${period.days}")
+      .toggleable(value = selected, role = Role.Checkbox, onValueChange = setSelected),
+    Arrangement.Start,
+    Alignment.CenterVertically
+  ) {
+    Checkbox(selected, null)
+    Text(period.label(), fontSize = 10.sp)
   }
 }


### PR DESCRIPTION
Closes #931.

## The problem

Every toggle row in the app put the state on the control and the label on a sibling node. A screen reader stopped twice: once on text with no state, once on a state with no name. That is exactly what @Anshu-Bijarnia reported, and the extra swipes to find out *what* was toggled are the cognitive load described in the issue.

## What changed

Three rows, all the same shape. Each is now a single toggleable node with an explicit role, and the control hands over its `onCheckedChange` so it stops being a second stop repeating the same state.

| Composable | Was |
|---|---|
| `SwitchListItem` | 8 settings rows; label and switch were separate nodes |
| `DaysCheckbox` (`MultiPeriodSelect`) | label carried a bare `clickable`, so a second stop with no role and no checked state |
| vibrate row (`ComposeHitTimer`) | label not associated with the checkbox at all |

## `mergeDescendants` alone does not fix `SwitchListItem`

Worth calling out, because the issue suggests it and I tried it first. `Modifier.toggleable` already merges descendants, but Material's `ListItem` **is itself a merging node**, so the label never reaches the toggleable node. Dumping the semantics tree on device with that fix in place:

```
Node #152                          <- the toggleable row
  Role = 'Switch'
  ToggleableState = 'Off'
  MergeDescendants = 'true'
   |-Node #153                     <- ListItem, still its own stop
     Text = '[LabelHere, DescriptionHere]'
     MergeDescendants = 'true'
```

Two nodes, so two stops: the bug survives. What collapses it is clearing the `ListItem`'s semantics and naming the row instead:

```
Node #152
  ContentDescription = '[LabelHere. DescriptionHere]'
  Role = 'Switch'
  ToggleableState = 'Off'
  Actions = [OnClick, OnFillData, RequestFocus]
  MergeDescendants = 'true'
```

One node. TalkBack reads the label, the description, the role and the state in a single stop.

## Side effect worth reviewing

Tapping anywhere on the row now toggles it, not just the control. That is the standard Material behaviour and a bigger target helps motor accessibility too, but it is a real behaviour change, so flagging it rather than burying it.

## Verification

Four new instrumented tests, all passing on a Pixel 9a emulator. They assert the row collapses to exactly one toggleable node (`onAllNodes(isToggleable()).fetchSemanticsNodes().size shouldBe 1`), which is what actually catches a regression here. Asserting only "the row toggles" would have passed against the broken version above.

`./gradlew detekt` and `testFdroidDebugUnitTest` both green.

## Not in this PR

- **`PauseCard`'s switch** has the same defect, but its row also holds Edit and Delete buttons, so it needs a `contentDescription` naming the specific pause rather than a toggleable row. Different technique, wants its own change.
- **#1044** proposes `android:nextFocusForward` for focus order, which cannot apply here: the app has zero XML layouts. That needs `traversalIndex` semantics instead, and the issue is still waiting on a maintainer answer about how to split it up.

## Unrelated breakage found

`ComposeHitTimerTest` fails on `main` today, before this branch. `SettingsRepository.kt:56` defaults `isHitTimerMillisecondsEnabled` to `false`, but the test expects the `"10:000"` millisecond format. I verified it fails identically with this branch stashed, so it is not caused here. CI never runs `androidTest`, which is why it went unnoticed. Happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
