### PR TITLE
✅ Pin the countdown format the hit timer tests assert on

### DIFF
--- a/app/src/androidTest/kotlin/br/com/colman/petals/hittimer/ComposeHitTimerTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/hittimer/ComposeHitTimerTest.kt
@@ -9,12 +9,33 @@ import androidx.compose.ui.test.runAndroidComposeUiTest
 import androidx.compose.ui.test.waitUntilExactlyOneExists
 import br.com.colman.kotest.FunSpec
 import br.com.colman.petals.MainActivity
+import br.com.colman.petals.koin
+import br.com.colman.petals.settings.SettingsRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 
+/**
+ * The countdown format is a user setting, and these tests were written against the millisecond one
+ * while [SettingsRepository.isHitTimerMillisecondsEnabled] defaults to off. That left them asserting
+ * "10:000" against a screen reading "10", so every one of them failed on a device. Each test now
+ * pins the format it needs rather than inheriting whatever the device happens to hold.
+ */
 @OptIn(ExperimentalTestApi::class)
 class ComposeHitTimerTest : FunSpec({
 
+  val settingsRepository = koin.get<SettingsRepository>()
+
+  // Writing the preference is not enough: the store hands the new value to collectAsState on its own
+  // schedule, so composing straight after the write can still read the previous format and the
+  // assertion races it. Block until the flow reports the value we asked for.
+  fun useMillisecondFormat(enabled: Boolean) {
+    settingsRepository.setIsHitTimerMillisecondsEnabled(enabled)
+    runBlocking { settingsRepository.isHitTimerMillisecondsEnabled.first { it == enabled } }
+  }
+
   test("Start Timer Test") {
     runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(true)
       activity!!.setContent {
         ComposeHitTimer()
       }
@@ -28,6 +49,7 @@ class ComposeHitTimerTest : FunSpec({
 
   test("Reset Timer Test") {
     runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(true)
       activity!!.setContent {
         ComposeHitTimer()
       }
@@ -35,12 +57,15 @@ class ComposeHitTimerTest : FunSpec({
       onNodeWithText("Start").performClick()
       waitUntilExactlyOneExists(hasText("09:0", true), 5000)
       onNodeWithText("Reset").performClick()
-      onNodeWithText("10:000").assertExists()
+      // Reset does not repaint the countdown on its own: millisElapsed only re-emits after its
+      // delay(100), so asserting straight away races the flow.
+      waitUntilExactlyOneExists(hasText("10:000"), 5000)
     }
   }
 
   test("Timer Completes Test") {
     runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(true)
       activity!!.setContent {
         ComposeHitTimer()
       }
@@ -53,6 +78,7 @@ class ComposeHitTimerTest : FunSpec({
 
   test("UI Element Visibility Test") {
     runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(true)
       activity!!.setContent {
         ComposeHitTimer()
       }
@@ -61,6 +87,31 @@ class ComposeHitTimerTest : FunSpec({
       onNodeWithText("Start").assertExists()
       onNodeWithText("Reset").assertExists()
       onNodeWithText("Vibrate on timer end").assertExists()
+    }
+  }
+
+  // The format users actually get by default, and the one nothing covered until now.
+  test("countdown uses whole seconds when milliseconds are off") {
+    runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(false)
+      activity!!.setContent {
+        ComposeHitTimer()
+      }
+
+      onNodeWithText("10").assertExists()
+      onNodeWithText("10:000").assertDoesNotExist()
+    }
+  }
+
+  test("countdown drops to one decimal under a second") {
+    runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(false)
+      activity!!.setContent {
+        ComposeHitTimer()
+      }
+
+      onNodeWithText("Start").performClick()
+      waitUntilExactlyOneExists(hasText("0.0"), 11000)
     }
   }
 })


### PR DESCRIPTION
Follow-up to the breakage flagged in #1117.

## The problem

Every test in `ComposeHitTimerTest` failed on a device, 4 out of 4. They assert the millisecond countdown:

```kotlin
onNodeWithText("10:000").assertExists()
```

but `SettingsRepository.kt:56` defaults the format off:

```kotlin
val isHitTimerMillisecondsEnabled = datastore.data.map { it[IsHitTimerMillisecondsEnabled] ?: false }
```

With it off the screen renders `formatDurationShort(10_000)`, which is `"10"`. The tests were asserting against a format the app does not show by default. CI never runs `androidTest`, so this sat unnoticed.

## Three separate races, not one

Worth spelling out, because fixing only the first still left the spec failing.

**1. The format itself.** Each test now pins what it needs instead of inheriting whatever the device happens to hold.

**2. The write does not land before composition.** Calling `setIsHitTimerMillisecondsEnabled(true)` and composing immediately still failed once the spec ran alongside others: DataStore hands the value to `collectAsState` on its own schedule, so the first emission can be the previous format. Blocking until the flow reports the value we asked for makes it deterministic:

```kotlin
fun useMillisecondFormat(enabled: Boolean) {
  settingsRepository.setIsHitTimerMillisecondsEnabled(enabled)
  runBlocking { settingsRepository.isHitTimerMillisecondsEnabled.first { it == enabled } }
}
```

**3. Reset does not repaint.** `millisElapsed` only re-emits after its `delay(100)`, so asserting straight after tapping Reset races the flow. That assertion now waits, like the surrounding ones already did.

Only the first was visible when the spec ran alone. The second surfaced when it ran next to other specs, which is how it will run in practice.

## Also covered

Two tests for the whole-second format: `"10"` at rest and `"0.0"` under a second. That is the default every user gets, and nothing exercised it before.

## Verification

6 of 6 pass on a Pixel 9a emulator. Run twice more interleaved with `SwitchListItemTest` and `DaysCheckboxTest`, 10 of 10 both times, which is what proves the cross-spec race is actually gone rather than merely quiet.

`./gradlew detekt` and `testFdroidDebugUnitTest` green.

## Not fixed here

`ComposeHitTimer` seeds `collectAsState(true)` while the repository defaults to `false`. Two disagreeing defaults for one setting, and the seed is the one that is wrong. It is a one-line app change rather than a test change, so it is not in this PR, but it is the reason the original tests looked correct when they were written.

Worth deciding separately whether CI should run `androidTest` on an emulator. Nothing would have caught this otherwise, and the same blind spot covers the accessibility tests added in #1117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
