### PR TITLE
✅ Get the instrumented suite green end to end

### DIFF
--- a/app/src/androidTest/kotlin/br/com/colman/petals/DevTooling.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/DevTooling.kt
@@ -1,0 +1,15 @@
+package br.com.colman.petals
+
+/**
+ * Marks a spec that drives developer tooling rather than verifying behaviour, so it needs something
+ * CI does not have: a listening machine, a checked-in artifact, a human reading the output.
+ *
+ * Excluded from automated runs with:
+ *
+ *     -Pandroid.testInstrumentationRunnerArguments.notAnnotation=br.com.colman.petals.DevTooling
+ *
+ * The marker lives on the class rather than in the workflow so the reason travels with the test.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class DevTooling

--- a/app/src/androidTest/kotlin/br/com/colman/petals/KoinModuleTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/KoinModuleTest.kt
@@ -1,16 +1,31 @@
-@file:OptIn(ExperimentalTestApi::class)
-
 package br.com.colman.petals
 
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runAndroidComposeUiTest
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import br.com.colman.kotest.FunSpec
+import org.koin.android.ext.koin.androidContext
+import org.koin.dsl.koinApplication
 import org.koin.test.check.checkModules
 
+/**
+ * checkModules closes the container it verifies. Pointed at the application's own Koin, as this
+ * spec used to be, it left the root scope closed for the rest of the run, and every later test died
+ * resolving anything with "Scope '_root_' is closed" - a crash that took the whole suite with it.
+ *
+ * Verifying a throwaway container over the same modules gives the same signal and leaves the
+ * running application untouched.
+ */
 class KoinModuleTest : FunSpec({
   test("Koin can resolve all modules") {
-    runAndroidComposeUiTest<MainActivity> {
-      koin.checkModules()
+    val application = koinApplication {
+      androidContext(ApplicationProvider.getApplicationContext<Context>())
+      modules(KoinModule)
+    }
+
+    try {
+      application.checkModules()
+    } finally {
+      application.close()
     }
   }
 })

--- a/app/src/androidTest/kotlin/br/com/colman/petals/ScreenshotTakerTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/ScreenshotTakerTest.kt
@@ -41,6 +41,11 @@ val locales = listOf(
   "uk" to ""
 )
 
+/**
+ * Not a test of behaviour: this regenerates the store listing screenshots and uploads them to a
+ * server running on the developer's machine, so it cannot pass anywhere else.
+ */
+@DevTooling
 class ScreenshotTakerTest : FunSpec({
 
   var usesImported = false

--- a/app/src/androidTest/kotlin/br/com/colman/petals/hittimer/ComposeHitTimerTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/hittimer/ComposeHitTimerTest.kt
@@ -42,7 +42,7 @@ class ComposeHitTimerTest : FunSpec({
 
       onNodeWithText("10:000").assertExists()
       onNodeWithText("Start").performClick()
-      waitUntilExactlyOneExists(hasText("09:0", true), 5000)
+      waitUntilExactlyOneExists(hasText("09:0", true), TimeoutMillis)
       onNodeWithText("10:000").assertDoesNotExist()
     }
   }
@@ -55,11 +55,11 @@ class ComposeHitTimerTest : FunSpec({
       }
 
       onNodeWithText("Start").performClick()
-      waitUntilExactlyOneExists(hasText("09:0", true), 5000)
+      waitUntilExactlyOneExists(hasText("09:0", true), TimeoutMillis)
       onNodeWithText("Reset").performClick()
       // Reset does not repaint the countdown on its own: millisElapsed only re-emits after its
       // delay(100), so asserting straight away races the flow.
-      waitUntilExactlyOneExists(hasText("10:000"), 5000)
+      waitUntilExactlyOneExists(hasText("10:000"), TimeoutMillis)
     }
   }
 
@@ -71,7 +71,7 @@ class ComposeHitTimerTest : FunSpec({
       }
 
       onNodeWithText("Start").performClick()
-      waitUntilExactlyOneExists(hasText("00:000"), 11000)
+      waitUntilExactlyOneExists(hasText("00:000"), TimeoutMillis + 10_000)
       onNodeWithText("00:000").assertExists()
     }
   }
@@ -111,7 +111,14 @@ class ComposeHitTimerTest : FunSpec({
       }
 
       onNodeWithText("Start").performClick()
-      waitUntilExactlyOneExists(hasText("0.0"), 11000)
+      waitUntilExactlyOneExists(hasText("0.0"), TimeoutMillis + 10_000)
     }
   }
 })
+
+/**
+ * The countdown ticks once a second, so any of these waits is generous on a developer machine. It is
+ * the shared CI emulator that needs the headroom: at five seconds this spec failed roughly one run in
+ * three once it ran alongside the rest of the suite. The budget still fails a genuinely stuck timer.
+ */
+private const val TimeoutMillis = 20_000L

--- a/app/src/androidTest/kotlin/br/com/colman/petals/use/io/UseIOModuleTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/use/io/UseIOModuleTest.kt
@@ -24,10 +24,13 @@ class UseIOModuleTest : FunSpec({
   test("should import and export data maintaining integrity") {
     val inputFile = File(ApplicationProvider.getApplicationContext<Context>().filesDir, "test_input.csv")
 
+    // Every column the exporter writes, in its order. The fixture used to stop at `id`, from before
+    // description and consumption method existed, so the round trip compared four columns against
+    // six and could never match.
     inputFile.writeText(
       """
-        date,amount,cost_per_gram,id
-        2024-03-21T19:01:47.163,0.08,22.2,80204597-00eb-4412-b7ee-223388806fe2
+        date,amount,cost_per_gram,id,description,consumption_method
+        2024-03-21T19:01:47.163,0.08,22.2,80204597-00eb-4412-b7ee-223388806fe2,,
       """.trimIndent()
     )
 


### PR DESCRIPTION
Groundwork for running `androidTest` in CI. Wiring up an emulator job is easy; the suite not passing was the actual problem.

## Starting point

Running everything on a device gave **2 tests run, 1 failed, 18 never started**. The process crashed partway and took the rest with it.

## Four independent causes

**1. `KoinModuleTest` poisoned every test after it.** It called `checkModules()` on the application's own Koin, and `checkModules` closes the container it verifies. Everything scheduled afterwards died in `MainActivity`:

```
FATAL EXCEPTION: main
Caused by: org.koin.core.error.ClosedScopeException: Scope '_root_' is closed
  at br.com.colman.petals.MainActivity.getSettingsRepository(MainActivity.kt:61)
```

That is the crash that ended the run. It now verifies a throwaway `koinApplication` over the same modules, so the signal is unchanged and the running app is left alone.

**2. `ScreenshotTakerTest` cannot pass off a developer machine.** It regenerates the store artwork and uploads it to `10.0.2.2:8081`. Marked `@DevTooling` and dropped by annotation rather than by class name in the workflow, so the reason lives next to the test:

```
-Pandroid.testInstrumentationRunnerArguments.notAnnotation=br.com.colman.petals.DevTooling
```

**3. `UseIOModuleTest` had a stale fixture.** It round-trips a CSV through import and export and compares the files, but the fixture stops at four columns while `UseCsvHeaders` writes six. `description` and `consumption_method` were added and the fixture was not, so the comparison could never match.

**4. `ComposeHitTimerTest` was timing out.** Five seconds for a countdown that ticks once a second is ample locally, and it passed 10 out of 10 in isolation. Once it competed with the rest of the suite it failed about one run in three, so the waits get headroom for a slower shared machine.

Only the first was visible from a single run. The others surfaced one at a time as each unblocked the next.

## Result

**22 of 22 passing, three consecutive runs**, using the exact command CI will use. On CI it will be 21: `SvgPrintSpikeTest` is local work in progress, not on `main` yet.

`./gradlew detekt` and `testFdroidDebugUnitTest` green.

## Next

The workflow itself comes in a follow-up: Gradle Managed Devices, so the device is declared in `build.gradle.kts` and the same command runs locally and on CI without a third-party action. Keeping it separate so this one stays reviewable as "make the tests correct".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
