### PR TITLE
👷 Run the instrumented suite on CI

### DIFF
--- a/.github/workflows/instrumented-tests.main.kts
+++ b/.github/workflows/instrumented-tests.main.kts
@@ -1,0 +1,89 @@
+#!/usr/bin/env kotlin
+@file:Repository("https://repo1.maven.org/maven2/")
+@file:Repository("https://central.sonatype.com/repository/maven-snapshots/")
+@file:DependsOn("io.github.typesafegithub:github-workflows-kt:4.0.0")
+
+@file:Repository("https://bindings.krzeminski.it")
+@file:DependsOn("actions:checkout:v4")
+@file:DependsOn("actions:setup-java:v5")
+@file:DependsOn("actions:cache:v4")
+@file:DependsOn("actions:upload-artifact:v4")
+@file:DependsOn("gradle:actions__setup-gradle:v4")
+
+import io.github.typesafegithub.workflows.actions.actions.Cache
+import io.github.typesafegithub.workflows.actions.actions.Checkout
+import io.github.typesafegithub.workflows.actions.actions.SetupJava
+import io.github.typesafegithub.workflows.actions.actions.UploadArtifact
+import io.github.typesafegithub.workflows.actions.gradle.ActionsSetupGradle
+import io.github.typesafegithub.workflows.domain.RunnerType
+import io.github.typesafegithub.workflows.domain.triggers.PullRequest
+import io.github.typesafegithub.workflows.domain.triggers.Push
+import io.github.typesafegithub.workflows.dsl.expressions.expr
+import io.github.typesafegithub.workflows.dsl.workflow
+
+// The device itself is declared in app/build.gradle.kts as a Gradle managed device, not here, so the
+// same command reproduces this run on a laptop. Changing the image is a Gradle edit, not a CI edit.
+private val DEVICE_TASK = "pixel6Api34FdroidDebugAndroidTest"
+
+// ScreenshotTakerTest regenerates store artwork and uploads it to a server on the developer's
+// machine, so it can only fail here. It carries @DevTooling and is filtered out by annotation.
+private val SKIP_DEV_TOOLING =
+  "-Pandroid.testInstrumentationRunnerArguments.notAnnotation=br.com.colman.petals.DevTooling"
+
+workflow(
+  name = "Instrumented Tests",
+  on = listOf(Push(branches = listOf("main")), PullRequest()),
+  sourceFile = __FILE__
+) {
+  // Its own workflow rather than folded into unit tests: it needs KVM, it is far slower, and a
+  // failure here means something different from a JVM test failure.
+  job(id = "instrumented-test", runsOn = RunnerType.UbuntuLatest, timeoutMinutes = 45) {
+    uses(name = "Setup JDK", action = SetupJava(javaVersion = "17", distribution = SetupJava.Distribution.Adopt))
+    uses(name = "Checkout", action = Checkout())
+    uses(name = "Setup Gradle", action = ActionsSetupGradle())
+
+    // Without this the runner exposes /dev/kvm to root only, and the device falls back to software
+    // emulation, which is too slow to finish inside any sane timeout.
+    run(
+      name = "Enable KVM group perms",
+      command = """
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+      """.trimIndent()
+    )
+
+    // Gradle provisions the image on first use. Caching it keeps later runs from re-downloading a
+    // system image that only changes when the device declaration does.
+    uses(
+      name = "Cache the managed device image",
+      action = Cache(
+        path = listOf(
+          "~/.android/avd",
+          "~/.android/adb*",
+          "~/.android/gradle/avd"
+        ),
+        key = "gmd-${expr { runner.os }}-$DEVICE_TASK",
+      )
+    )
+
+    run(
+      name = "Run Instrumented Tests",
+      command = "./gradlew :app:$DEVICE_TASK $SKIP_DEV_TOOLING"
+    )
+
+    // The XML says which test failed; the HTML report says how. Worth keeping when it goes red,
+    // because nobody can reproduce an emulator failure by staring at the log.
+    uses(
+      name = "Upload instrumented test report",
+      condition = expr { failure() },
+      action = UploadArtifact(
+        name = "instrumented-test-report",
+        path = listOf(
+          "app/build/reports/androidTests",
+          "app/build/outputs/androidTest-results"
+        )
+      )
+    )
+  }
+}

--- a/.github/workflows/instrumented-tests.yaml
+++ b/.github/workflows/instrumented-tests.yaml
@@ -1,0 +1,69 @@
+# This file was generated using Kotlin DSL (.github/workflows/instrumented-tests.main.kts).
+# If you want to modify the workflow, please change the Kotlin file and regenerate this YAML file.
+# Generated with https://github.com/typesafegithub/github-workflows-kt
+
+name: 'Instrumented Tests'
+on:
+  push:
+    branches:
+    - 'main'
+  pull_request: {}
+jobs:
+  check_yaml_consistency:
+    name: 'Check YAML consistency'
+    runs-on: 'ubuntu-latest'
+    steps:
+    - id: 'step-0'
+      name: 'Check out'
+      uses: 'actions/checkout@v4'
+    - id: 'step-1'
+      name: 'Execute script'
+      run: 'rm ''.github/workflows/instrumented-tests.yaml'' && ''.github/workflows/instrumented-tests.main.kts'''
+    - id: 'step-2'
+      name: 'Consistency check'
+      run: 'git diff --exit-code ''.github/workflows/instrumented-tests.yaml'''
+  instrumented-test:
+    runs-on: 'ubuntu-latest'
+    needs:
+    - 'check_yaml_consistency'
+    timeout-minutes: 45
+    steps:
+    - id: 'step-0'
+      name: 'Setup JDK'
+      uses: 'actions/setup-java@v5'
+      with:
+        java-version: '17'
+        distribution: 'adopt'
+    - id: 'step-1'
+      name: 'Checkout'
+      uses: 'actions/checkout@v4'
+    - id: 'step-2'
+      name: 'Setup Gradle'
+      uses: 'gradle/actions/setup-gradle@v4'
+    - id: 'step-3'
+      name: 'Enable KVM group perms'
+      run: |-
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - id: 'step-4'
+      name: 'Cache the managed device image'
+      uses: 'actions/cache@v4'
+      with:
+        path: |-
+          ~/.android/avd
+          ~/.android/adb*
+          ~/.android/gradle/avd
+        key: 'gmd-${{ runner.os }}-pixel6Api34FdroidDebugAndroidTest'
+    - id: 'step-5'
+      name: 'Run Instrumented Tests'
+      run: './gradlew :app:pixel6Api34FdroidDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.notAnnotation=br.com.colman.petals.DevTooling'
+    - id: 'step-6'
+      name: 'Upload instrumented test report'
+      uses: 'actions/upload-artifact@v4'
+      with:
+        name: 'instrumented-test-report'
+        path: |-
+          app/build/reports/androidTests
+          app/build/outputs/androidTest-results
+      if: '${{ failure() }}'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -133,6 +133,25 @@ android {
       isIncludeAndroidResources = true
       all { it.useJUnitPlatform() }
     }
+
+    // Declaring the device here rather than provisioning one in the workflow means CI and a laptop
+    // run the same command against the same image, and a green run is reproducible off CI.
+    // aosp-atd is the automated-test image: no Play services and no UI shell, which is what makes it
+    // quick enough to boot on a shared runner.
+    managedDevices {
+      localDevices {
+        create("pixel6Api34") {
+          device = "Pixel 6"
+          apiLevel = 34
+          systemImageSource = "aosp-atd"
+          // AGP 10 flips the default to arm64-v8a, which this image cannot translate, and AGP 9.2.1
+          // asks in a build warning for exactly this line. Note it has no effect yet: setting
+          // "arm64-v8a" here still runs all tests green and still prints the "does not specify a
+          // testedAbi" warning, so 9.2.1 is not reading it. Kept for the upgrade, not for today.
+          testedAbi = "x86_64"
+        }
+      }
+    }
   }
 
   packaging {


### PR DESCRIPTION
Follow-up to #1119, which made the suite pass. This runs it.

Until now `androidTest` ran nowhere but a developer's machine, so the accessibility tests from #1117 and the hit timer tests from #1118 were guarded by something nothing executed.

## Gradle managed device, not an emulator action

The device is declared in `app/build.gradle.kts`:

```kotlin
managedDevices {
  localDevices {
    create("pixel6Api34") {
      device = "Pixel 6"
      apiLevel = 34
      systemImageSource = "aosp-atd"
    }
  }
}
```

So `./gradlew :app:pixel6Api34FdroidDebugAndroidTest` is the whole thing, and it is the same command locally and on CI. Changing the image is a Gradle edit rather than a workflow edit, and a red CI run is reproducible without guessing what the runner provisioned.

`aosp-atd` is Google's automated-test image: no Play services, no UI shell. That is what makes it boot fast enough for a shared runner, and it suits the `fdroid` flavour, which has no Play services dependency anyway.

## Verification

Run locally against that managed device, not just asserted to work:

```
Starting 22 tests on pixel6Api34
BUILD SUCCESSFUL in 1m 11s
22 tests, 0 failures
```

CI will run 21; the 22nd is `SvgPrintSpikeTest`, local work in progress not on `main`.

The YAML is generated from the `.main.kts`, and I ran the consistency check the same way CI does (`rm` the yaml, re-run the script, `git diff --exit-code`) - clean.

## `testedAbi` is deliberately inert

AGP 9.2.1 prints:

```
The device "pixel6Api34" does not specify a "testedAbi".
This currently defaults to "x86_64", but will change to "arm64-v8a" in AGP 10.0.
explicitly set the ABI: testedAbi = "x86_64"
```

I added exactly that line, then checked whether it does anything. It does not: setting `testedAbi = "arm64-v8a"` on an image that cannot translate arm64 still ran all 22 tests green and still printed the same "does not specify" warning. So 9.2.1 is not reading the property on this DSL path.

Kept anyway, since it is what AGP's own message asks for and it is the value the AGP 10 upgrade will want, but the comment says plainly that it has no effect today rather than implying the warning is handled.

## Notes for review

- **45 minute job timeout.** The run takes about a minute after the image is cached; the ceiling is for a cold provision.
- **The cache key** covers `~/.android/avd`, `~/.android/adb*` and `~/.android/gradle/avd`. First run on CI pays the image download.
- **Report upload on failure.** The XML says which test failed, the HTML says how, and neither is guessable from a log.
- There is an unpushed local branch `ci/instrumented-tests` with an earlier take on this using `reactivecircus/android-emulator-runner`. This supersedes it; worth deleting if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
