### PR TITLE
🐛 Give the widget an initial layout so it can be placed

### DIFF
--- a/app/src/androidTest/kotlin/br/com/colman/petals/widgets/AddLastUseWidgetProviderTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/widgets/AddLastUseWidgetProviderTest.kt
@@ -1,0 +1,26 @@
+package br.com.colman.petals.widgets
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import br.com.colman.kotest.FunSpec
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * The launcher inflates [android.appwidget.AppWidgetProviderInfo.initialLayout] before Glance ever
+ * runs, so a provider without one asks it to inflate resource 0. That surfaces to the user as
+ * "Can't load widget", with `Resources$NotFoundException: Resource ID #0x0` in the log, and the
+ * widget can never be placed. The attribute had been missing since the widget was written.
+ */
+class AddLastUseWidgetProviderTest : FunSpec({
+
+  test("the widget provider declares an initial layout") {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+
+    val provider = AppWidgetManager.getInstance(context)
+      .getInstalledProvidersForPackage(context.packageName, null)
+      .single { it.provider.className == AddLastUseWidgetReciever::class.java.name }
+
+    provider.initialLayout shouldNotBe 0
+  }
+})

--- a/app/src/main/res/xml/appwidget_info.xml
+++ b/app/src/main/res/xml/appwidget_info.xml
@@ -6,4 +6,5 @@
     android:updatePeriodMillis="1800000"
     android:minWidth="250dp"
     android:minHeight="110dp"
+    android:initialLayout="@layout/glance_default_loading_layout"
     />


### PR DESCRIPTION
The home screen widget could not be placed at all. Dragging it out of the picker gave "Can't load widget".

![Widget before and after](https://raw.githubusercontent.com/LeoColman/Petals/assets/widget-fix/widget-before-after.png)

## Cause

`app/src/main/res/xml/appwidget_info.xml` never declared `android:initialLayout`:

```
W AppWidgetHostView: Error inflating AppWidget ComponentInfo{...AddLastUseWidgetReciever}
W AppWidgetHostView: android.content.res.Resources$NotFoundException: Resource ID #0x0
```

The launcher inflates that layout itself, in its own process, before Glance ever runs. With the attribute absent the field defaults to `0`, so the host is asked to inflate resource `0` and fails. `dumpsys appwidget` showed it plainly: `initialLayout=#0` for our provider, a real id for every other widget on the device.

The fix points it at Glance's own loading layout, which exists for exactly this: what the launcher shows between placing the widget and Glance pushing real content.

## Not a recent regression

This was raised as possibly caused by the recent theme work, so I checked before assuming either way.

- `initialLayout` has been absent since the widget was added in #980. It is in neither commit that ever touched that file.
- The old **3.41.2** release was still installed on my emulator, from before any of that work. It fails identically, `Resource ID #0x0` under `ComponentInfo{br.com.colman.petals/...}`, while the current build fails under `...petals.debug`. Same bug, both sides of the change.

What the theme work did change is the button colour, visible in the AFTER shot: `ButtonDefaults.buttonColors()` picks up `primary` through `GlanceTheme`, so the widget button is the dimmed `#879017` now. That is the intended #903 change, not this bug.

## Verification

Placed on a Pixel 9a emulator and exercised end to end:

1. Widget places, no "Can't load widget", `App widget with id: 6 loaded`.
2. Empty state renders "No previous use found" with an "Add Use" button, which opens `MainActivity`.
3. After recording a use, it shows `Date: 2026-08-04 at 18:46` / `Amount: 0g` and the button becomes "Add a copy of my last use".
4. Tapping that records a use and the widget refreshes itself: the timestamp moved to `18:47`. No crash in logcat.

New instrumented test asserts the provider reports a non-zero `initialLayout`. Mutation-checked by removing the attribute again, where it fails with `0 should not equal 0`, so it genuinely guards this and would have caught it on the day the widget was written.

Full instrumented suite 23 of 23 green, `detekt` and `testFdroidDebugUnitTest` green. The new test runs on CI, since #1120 wired `androidTest` in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
