### PR TITLE
🐛 Give the toggles back their touch target

### DIFF
--- a/app/src/androidTest/kotlin/br/com/colman/petals/hittimer/ComposeHitTimerTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/hittimer/ComposeHitTimerTest.kt
@@ -2,11 +2,14 @@ package br.com.colman.petals.hittimer
 
 import androidx.activity.compose.setContent
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runAndroidComposeUiTest
 import androidx.compose.ui.test.waitUntilExactlyOneExists
+import androidx.compose.ui.unit.dp
 import br.com.colman.kotest.FunSpec
 import br.com.colman.petals.MainActivity
 import br.com.colman.petals.koin
@@ -87,6 +90,19 @@ class ComposeHitTimerTest : FunSpec({
       onNodeWithText("Start").assertExists()
       onNodeWithText("Reset").assertExists()
       onNodeWithText("Vibrate on timer end").assertExists()
+    }
+  }
+
+  // Handing the toggle to the row costs the checkbox the sizing Material only applies while a
+  // control handles its own changes, which collapses the space around the box.
+  test("the vibrate row keeps a full touch target") {
+    runAndroidComposeUiTest<MainActivity> {
+      useMillisecondFormat(false)
+      activity!!.setContent {
+        ComposeHitTimer()
+      }
+
+      onNode(hasText("Vibrate on timer end") and isToggleable()).assertHeightIsAtLeast(48.dp)
     }
   }
 

--- a/app/src/androidTest/kotlin/br/com/colman/petals/statistics/component/DaysCheckboxTest.kt
+++ b/app/src/androidTest/kotlin/br/com/colman/petals/statistics/component/DaysCheckboxTest.kt
@@ -5,12 +5,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHeightIsAtLeast
 import androidx.compose.ui.test.assertIsOff
 import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertWidthIsAtLeast
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runAndroidComposeUiTest
+import androidx.compose.ui.unit.dp
 import br.com.colman.kotest.FunSpec
 import br.com.colman.petals.MainActivity
 import io.kotest.matchers.shouldBe
@@ -47,4 +50,21 @@ class DaysCheckboxTest : FunSpec({
       onNodeWithTag("Days 7").assertIsOn()
     }
   }
+
+  // Handing the toggle to the row costs the checkbox the sizing Material only applies while a
+  // control handles its own changes. The visible symptom is the box sitting flush against its
+  // label, with the period chips crammed together; the measurable one is the touch target.
+  test("the checkbox keeps its full touch target") {
+    runAndroidComposeUiTest<MainActivity> {
+      activity!!.setContent {
+        DaysCheckbox(false, { }, Period.Week)
+      }
+
+      onNodeWithTag("Days 7")
+        .assertHeightIsAtLeast(MinimumTouchTarget)
+        .assertWidthIsAtLeast(MinimumTouchTarget)
+    }
+  }
 })
+
+private val MinimumTouchTarget = 48.dp

--- a/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/hittimer/ComposeHitTimer.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -117,7 +118,7 @@ fun ComposeHitTimer(repository: HitTimerRepository = koinInject()) {
         Start,
         CenterVertically
       ) {
-        Checkbox(shouldVibrate, null)
+        Checkbox(shouldVibrate, null, Modifier.minimumInteractiveComponentSize())
         Text(stringResource(vibrate_on_timer_end))
       }
     }

--- a/app/src/main/kotlin/br/com/colman/petals/statistics/component/MultiPeriodSelect.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/statistics/component/MultiPeriodSelect.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.Text
+import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -65,7 +66,10 @@ fun DaysCheckbox(selected: Boolean, setSelected: (Boolean) -> Unit, period: Peri
     Arrangement.Start,
     Alignment.CenterVertically
   ) {
-    Checkbox(selected, null)
+    // Material sizes a control to the 48dp touch target only while it handles its own changes.
+    // Handing the toggle to the row drops that, and with it the breathing room around the box, so
+    // ask for the size back explicitly.
+    Checkbox(selected, null, Modifier.minimumInteractiveComponentSize())
     Text(period.label(), fontSize = 10.sp)
   }
 }


### PR DESCRIPTION
The period chips on the Stats page lost the space around their boxes.

![Checkbox margins before, regressed, and fixed](https://raw.githubusercontent.com/LeoColman/Petals/assets/checkbox-margins/checkbox-margins.png)

## Bisected, not guessed

`git bisect` over the range between the 3.43.1 and 3.43.2 release commits, driven by a script that builds, installs, opens Stats, and measures the left inset of the first checkbox in the screenshot. Good is `>= 30px`.

```
git bisect start ffd752c2 4fee6193
...
first bad commit: [6f41c4ee] ♿ Make toggle rows announce what they toggle (#931) (#1117)
```

Measured inset: **37px** before that commit, **5px** after, **37px** again with this fix.

## Cause

Material sizes a control to the 48dp touch target only while that control handles its own changes. #1117 moved the toggle onto the row, so a screen reader stops once instead of twice, and passed `null` to the control:

```kotlin
Checkbox(selected, null)
```

The row needed that. What went with it was the sizing, dropping the box from 48dp to 24dp and collapsing the layout around it. The fix asks for it back:

```kotlin
Checkbox(selected, null, Modifier.minimumInteractiveComponentSize())
```

Two places had the regression: the period chips, and the "Vibrate on timer end" checkbox on the hit timer, which is the same pattern and confirmed on device.

## What is deliberately not changed

`SwitchListItem` passes `null` the same way, and I fixed it too at first. Then I checked whether it actually regressed, and it did not: its row height comes from `ListItem`, so nothing collapsed and the row is already a full-size target. I reverted that edit rather than ship a change I could not justify.

I also wrote a touch-target test for it, and dropped that too: it passed with and without the fix, because `ListItem` holds the height either way. A test that cannot fail is worse than no test, since it implies coverage that is not there.

## Tests

Two UI tests, both asserting the 48dp minimum, which is the invariant behind the visible margin:

```kotlin
onNodeWithTag("Days 7")
  .assertHeightIsAtLeast(48.dp)
  .assertWidthIsAtLeast(48.dp)
```

Mutation-checked by stashing the fix and re-running. Both fail with `Actual height is 24.0.dp, expected at least 48.0.dp` — exactly half, which is the signature of the missing touch target.

Full instrumented suite 25 of 25 green, `detekt` and `testFdroidDebugUnitTest` green.

One note: `ComposeHitTimerTest :: Reset Timer Test` flaked once during this work, then passed three consecutive runs. That is the pre-existing flake from #1118 and not related to this change, but it is still not fully settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
