### PR TITLE
🐛 Keep the widget callback's constructor through R8

### DIFF
--- a/app/proguard-android-optimize.txt
+++ b/app/proguard-android-optimize.txt
@@ -15,6 +15,16 @@
 -keep class * extends androidx.room.RoomDatabase {
     <init>();
 }
+# Glance builds an ActionCallback reflectively when a widget button is tapped, so its no-arg
+# constructor has no caller R8 can see. glance-appwidget 1.1.1 ships
+# "-keep public class * extends androidx.glance.appwidget.action.ActionCallback", which keeps the
+# class but NOT its members, exactly like the Room rule above. R8 dropped
+# AddUseActionCallback.<init>(), so tapping "Add a copy of my last use" threw
+# NoSuchMethodException and silently did nothing. Only release builds are minified, which is why
+# the button worked in every debug test and failed for everyone who installed the app.
+-keep class * implements androidx.glance.appwidget.action.ActionCallback {
+    <init>();
+}
 -keep class * implements android.os.Parcelable {
   public static final android.os.Parcelable$Creator *;
 }


### PR DESCRIPTION
You were right, and my earlier verification was wrong. The widget button does nothing in released builds.

## What actually happens

Installed the published **3.43.2 APK** on an emulator, placed the widget, tapped the button:

```
E GlanceAppWidget: java.lang.NoSuchMethodException:
  br.com.colman.petals.widgets.AddUseActionCallback.<init> []
```

Glance builds an `ActionCallback` reflectively, so R8 sees no caller for its constructor. `glance-appwidget` 1.1.1 ships:

```
-keep public class * extends androidx.glance.appwidget.action.ActionCallback
```

That keeps the class but not its members — the same shape as the Room rule already documented in `proguard-android-optimize.txt`, which cost this project a launch crash once before.

Two independent confirmations from the shipped artifacts:

- `dexdump` on the 3.43.2 APK: the class is present with **no direct methods at all**.
- R8's own `usage.txt`, published as a release asset, lists what it deleted:

```
br.com.colman.petals.widgets.AddUseActionCallback:
    public static final int $stable
    public void <init>()
```

## Why my earlier test missed it

I verified the button on a **debug** build, saw the timestamp advance, and reported it working. Debug builds are not minified. The bug exists only where `isMinifyEnabled = true`, so the one build I could not reproduce it on was the only build I tested. That is the same trap the Room comment in this file already warns about, and I walked into it.

## The fix

A keep rule for the constructor, mirroring the Room one, with a comment explaining why it has to be there.

On a locally built, minified, signed release, the button now works. Timestamp advances and no exception:

![Widget button on a minified release build](https://raw.githubusercontent.com/LeoColman/Petals/assets/widget-button/widget-button-release.png)

Rebuilt after the fix, R8's `usage.txt` now lists only `$stable` under that class. The constructor survives.

## On automating the check

I had added a build step that read R8's removal log back and failed the build on a stripped callback constructor. Dropped at Leo's call: the comment carries the reasoning, and this file is not edited often enough to justify the machinery.

Worth knowing what that means: an instrumented test cannot cover this either, since `androidTest` builds are not minified and would pass either way. So this class of bug stays caught by reading the comment before touching R8 rules, not by CI.

`detekt` and `testFdroidDebugUnitTest` green; `assembleFdroidRelease` and `assemblePlaystoreRelease` build clean.

## Worth noting

The widget has never worked in a release build since it was added. #1121 fixed placing it; this fixes the button on it. Both were invisible to debug testing, which is worth remembering the next time something widget-shaped looks fine locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
