### PR TITLE
✨ Draw the withdrawal charts with Grafima

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,9 +43,7 @@ repositories {
 
 android {
   namespace = "br.com.colman.petals"
-  // Grafima 1.1.0 declares minCompileSdk=37, so compiling against 36 fails AAR metadata
-  // validation. targetSdk stays at 36: this only changes what we compile against.
-  compileSdk = 37
+  compileSdk = 36
 
   defaultConfig {
     applicationId = "br.com.colman.petals"
@@ -87,8 +85,7 @@ android {
 
     create("playstore") {
       dimension = "distribution"
-      // Raised from 23 to match Grafima, which is minSdk 24. Drops Android 6.0 on the Play Store.
-      minSdk = 24
+      minSdk = 23
       signingConfig = signingConfigs.findByName("self-sign")
     }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,9 @@ repositories {
 
 android {
   namespace = "br.com.colman.petals"
-  compileSdk = 36
+  // Grafima 1.1.0 declares minCompileSdk=37, so compiling against 36 fails AAR metadata
+  // validation. targetSdk stays at 36: this only changes what we compile against.
+  compileSdk = 37
 
   defaultConfig {
     applicationId = "br.com.colman.petals"
@@ -85,7 +87,8 @@ android {
 
     create("playstore") {
       dimension = "distribution"
-      minSdk = 23
+      // Raised from 23 to match Grafima, which is minSdk 24. Drops Android 6.0 on the Play Store.
+      minSdk = 24
       signingConfig = signingConfigs.findByName("self-sign")
     }
 
@@ -200,6 +203,10 @@ dependencies {
 
   // Graph Views
   implementation(libs.bundles.graph.view)
+
+  // Grafima: Compose-native charts. Spiking it on the withdrawal charts; the Stats charts and the
+  // hit timer still run on MPAndroidChart and GraphView.
+  implementation(libs.grafima)
 
   // Apache commons
   implementation(libs.bundles.apache.commons)

--- a/app/proguard-android-optimize.txt
+++ b/app/proguard-android-optimize.txt
@@ -34,3 +34,18 @@
 -dontwarn androidx.window.extensions.core.util.function.Consumer
 -dontwarn androidx.window.extensions.core.util.function.Function
 -dontwarn androidx.window.extensions.core.util.function.Predicate
+
+# androidx.window 1.5.0 arrives through Grafima's Compose Multiplatform chain. It reflects against
+# OEM window extensions that only exist on devices that ship them, so R8 sees them as missing.
+-dontwarn androidx.window.extensions.WindowExtensions
+-dontwarn androidx.window.extensions.WindowExtensionsProvider
+-dontwarn androidx.window.extensions.layout.DisplayFeature
+-dontwarn androidx.window.extensions.layout.FoldingFeature
+-dontwarn androidx.window.extensions.layout.WindowLayoutComponent
+-dontwarn androidx.window.extensions.layout.WindowLayoutInfo
+-dontwarn androidx.window.sidecar.SidecarDeviceState
+-dontwarn androidx.window.sidecar.SidecarDisplayFeature
+-dontwarn androidx.window.sidecar.SidecarInterface$SidecarCallback
+-dontwarn androidx.window.sidecar.SidecarInterface
+-dontwarn androidx.window.sidecar.SidecarProvider
+-dontwarn androidx.window.sidecar.SidecarWindowLayoutInfo

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
@@ -15,6 +15,7 @@ import io.grafima.charts.line.LineAxisConfig
 import io.grafima.charts.line.LineChart
 import io.grafima.charts.line.LineChartStyle
 import io.grafima.charts.line.LineCrosshairConfig
+import io.grafima.charts.line.LineCurveType
 import io.grafima.charts.line.LineDataPoint
 import io.grafima.charts.line.LineDataSet
 import io.grafima.charts.line.LineSeries
@@ -79,7 +80,9 @@ fun WithdrawalChart(
         contentDescription = context.graphTitle(currentValue)
       ),
       modifier = Modifier.fillMaxWidth().weight(1f),
-      style = LineChartStyle(showDots = true),
+      // Linear, not the default cubic. The marker's y comes from a linear Interpolator, so a
+      // smoothed curve bows away from the chord and leaves the dot floating off its own line.
+      style = LineChartStyle(showDots = true, curveType = LineCurveType.Linear),
       axisConfig = LineAxisConfig(
         gridColor = colors.primary,
         axisColor = colors.primary,

--- a/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
+++ b/app/src/main/kotlin/br/com/colman/petals/withdrawal/view/WithdrawalChart.kt
@@ -1,19 +1,30 @@
 package br.com.colman.petals.withdrawal.view
 
 import android.content.Context
-import androidx.compose.material.Colors
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
 import br.com.colman.petals.withdrawal.interpolator.Interpolator
 import br.com.colman.petals.withdrawal.tolerance.SecondsPerDay
-import com.jjoe64.graphview.GraphView
-import com.jjoe64.graphview.series.DataPoint
-import com.jjoe64.graphview.series.LineGraphSeries
-import com.jjoe64.graphview.series.PointsGraphSeries
+import io.grafima.charts.line.LineAxisConfig
+import io.grafima.charts.line.LineChart
+import io.grafima.charts.line.LineChartStyle
+import io.grafima.charts.line.LineCrosshairConfig
+import io.grafima.charts.line.LineDataPoint
+import io.grafima.charts.line.LineDataSet
+import io.grafima.charts.line.LineSeries
 import java.time.Duration
 
+/**
+ * The eight symptom curves are only comparable because every one of them is drawn on the same pinned
+ * scale, so the axis bounds here are the point of the chart rather than a detail. `xMin` is -1
+ * because one dataset carries a pre-abstinence baseline at day -1.
+ */
 @Composable
 @Suppress("LongParameterList")
 fun WithdrawalChart(
@@ -26,25 +37,65 @@ fun WithdrawalChart(
   maxY: Double,
 ) {
   val colors = MaterialTheme.colors
+  val context = LocalContext.current
   val scaledData = data.scaled(maxY)
-
   val interpolator = Interpolator(scaledData)
 
-  AndroidView({
-    createGraph(it, verticalAxisTitle, horizontalAxisTitle, effectiveAbstinence, colors, scaledData, maxX, maxY)
-  }, update = {
-    val currentValue = effectiveAbstinence?.let { abstinence -> chartPointFor(interpolator, abstinence, maxX).second }
-    it.title = graphTitle(it.context, currentValue)
-    it.removeAllSeries()
-    it.addSeries(scaledData.toLineGraphSeries().apply { color = colors.secondary.toArgb() })
+  val currentValue = effectiveAbstinence?.let { chartPointFor(interpolator, it, maxX).second }
 
-    if (effectiveAbstinence != null) {
-      it.addSeries(
-        currentPointSeries(interpolator, effectiveAbstinence, maxX).apply { color = colors.primary.toArgb() }
-      )
-    }
-    it.invalidate()
-  })
+  val curve = LineSeries(
+    id = "curve",
+    label = verticalAxisTitle,
+    points = scaledData.map { (duration, value) ->
+      LineDataPoint(duration.toDays().toFloat(), value.toFloat(), duration.toDays().toString())
+    },
+    color = colors.secondary
+  )
+
+  // "You are here" is a one-point series rather than an annotation, which is what the GraphView
+  // version did too. Dots are on for the whole chart, so the marker reads as a point on the curve.
+  val marker = effectiveAbstinence?.let {
+    val (x, y) = chartPointFor(interpolator, it, maxX)
+    LineSeries(
+      id = "marker",
+      label = "",
+      points = listOf(LineDataPoint(x.toFloat(), y.toFloat(), "")),
+      color = colors.primary
+    )
+  }
+
+  Column(Modifier.fillMaxWidth()) {
+    Text(
+      context.graphTitle(currentValue),
+      Modifier.fillMaxWidth(),
+      color = colors.onSurface,
+      textAlign = TextAlign.Center,
+      style = MaterialTheme.typography.subtitle2
+    )
+
+    LineChart(
+      dataSet = LineDataSet(
+        series = listOfNotNull(curve, marker),
+        contentDescription = context.graphTitle(currentValue)
+      ),
+      modifier = Modifier.fillMaxWidth().weight(1f),
+      style = LineChartStyle(showDots = true),
+      axisConfig = LineAxisConfig(
+        gridColor = colors.primary,
+        axisColor = colors.primary,
+        labelColor = colors.primary,
+        yMin = 0f,
+        yMax = maxY.toFloat(),
+        xMin = -1f,
+        xMax = maxX.toFloat(),
+        xAxisTitle = horizontalAxisTitle,
+        yAxisTitle = verticalAxisTitle
+      ),
+      // The marker already says where you are; a crosshair on top of a reference curve invites
+      // reading a precision that the study data does not carry.
+      crosshairConfig = LineCrosshairConfig(enabled = false)
+    )
+  }
 }
 
 /**
@@ -67,63 +118,4 @@ fun Map<Duration, Double>.scaled(maxY: Double): Map<Duration, Double> {
 fun chartPointFor(interpolator: Interpolator, abstinence: Duration, maxX: Double): Pair<Double, Double> {
   val days = (abstinence.seconds.toDouble() / SecondsPerDay).coerceIn(0.0, maxX)
   return days to interpolator.value(days * SecondsPerDay)
-}
-
-@Suppress("LongParameterList")
-private fun createGraph(
-  context: Context,
-  verticalAxisTitle: String,
-  horizontalAxisTitle: String,
-  effectiveAbstinence: Duration?,
-  colors: Colors,
-  data: Map<Duration, Double>,
-  maxX: Double,
-  maxY: Double
-) = GraphView(context).apply {
-  val interpolator = Interpolator(data)
-
-  addSeries(data.toLineGraphSeries())
-  if (effectiveAbstinence != null) addSeries(currentPointSeries(interpolator, effectiveAbstinence, maxX))
-
-  viewport.apply {
-    isXAxisBoundsManual = true
-    setMinX(-1.0)
-    setMaxX(maxX)
-
-    isYAxisBoundsManual = true
-    setMinY(0.0)
-    setMaxY(maxY)
-  }
-
-  gridLabelRenderer.apply {
-    titleColor = colors.onSurface.toArgb()
-    verticalAxisTitleColor = colors.onSurface.toArgb()
-    horizontalAxisTitleColor = colors.onSurface.toArgb()
-    horizontalLabelsColor = colors.primary.toArgb()
-    verticalLabelsColor = colors.primary.toArgb()
-    gridColor = colors.primary.toArgb()
-
-    this.verticalAxisTitle = verticalAxisTitle
-    this.horizontalAxisTitle = horizontalAxisTitle
-  }
-}
-
-private fun Map<Duration, Double>.toLineGraphSeries(): LineGraphSeries<DataPoint> {
-  val dataPoints = this.map { (key, value) -> DataPoint(key.toDays().toDouble(), value) }
-  return LineGraphSeries(dataPoints.toTypedArray()).apply {
-    isDrawDataPoints = true
-    dataPointsRadius = 8f
-  }
-}
-
-private fun currentPointSeries(
-  interpolator: Interpolator,
-  abstinence: Duration,
-  maxX: Double
-): PointsGraphSeries<DataPoint> {
-  val (x, y) = chartPointFor(interpolator, abstinence, maxX)
-  return PointsGraphSeries(arrayOf(DataPoint(x, y))).apply {
-    size = 15f
-    shape = PointsGraphSeries.Shape.POINT
-  }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compo
 datastore-android = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastore" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+grafima = "io.grafima:grafima:1.1.0"
 graph-view = "com.jjoe64:graphview:4.2.2"
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ compose-ui-test = { module = "androidx.compose.ui:ui-test", version.ref = "compo
 datastore-android = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
 datastore-core = { module = "androidx.datastore:datastore-core", version.ref = "datastore" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
-grafima = "io.grafima:grafima:1.1.0"
+grafima = "io.grafima:grafima:1.1.1"
 graph-view = "com.jjoe64:graphview:4.2.2"
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }
 koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }


### PR DESCRIPTION
Spike: the eight withdrawal charts (plus THC) move off GraphView onto Grafima 1.1.0. Stats and the hit timer stay where they are.

## Before and after

Same device, same database, same 7 days of abstinence. The GraphView build was installed, seeded, and captured; then this branch was installed **over it** without wiping data, so both sides read the identical state. Every title reports the same number on both sides, which is the parity claim.

**THC concentration**, pinned to `0..100`:

![THC](https://raw.githubusercontent.com/LeoColman/Petals/assets/grafima-spike/thc.png)

**Discomfort**, pinned to `0..10`, with the day -1 baseline:

![Discomfort](https://raw.githubusercontent.com/LeoColman/Petals/assets/grafima-spike/discomfort.png)

**Three more of the eight**, scrolled:

![More charts](https://raw.githubusercontent.com/LeoColman/Petals/assets/grafima-spike/more.png)

What changes, beyond the renderer:

- Grafima labels the x axis at the **actual data points** (0, 1, 2, 3, 4, 7, 10, 14, 20) instead of fixed ticks every 5.
- GraphView **clips**: look at the Discomfort chart's x labels in the "before" shots, cut off at the bottom, and the curve running past the right edge. Grafima fits the plot inside its box, showing -1 through 25.
- The marker is smaller. `showDots` and `dotRadius` are global in Grafima, so the marker cannot be drawn larger than the curve's own points the way GraphView did. It stays distinguishable by colour. This is the one parity loss.

On the third image, decreased appetite reads 4.34 before and 4.33 after. The two captures are a minute apart and that curve is steep at day 7, so the value sits on a rounding boundary; the marker is in the same place on both.

## A bug the comparison caught

Grafima defaults to `MonotoneCubic`. The marker's y comes from `Interpolator`, which is **linear**, so where the curve is convex the smoothed line bows away from the chord and the dot floats off its own curve. Only visible side by side at 4x:

![Marker off the line](https://raw.githubusercontent.com/LeoColman/Petals/assets/grafima-spike/zoom_marker.png)

Switching to `LineCurveType.Linear` puts it back on the line, matching what GraphView drew all along:

![Marker fixed](https://raw.githubusercontent.com/LeoColman/Petals/assets/grafima-spike/zoom_marker_fixed.png)

I would not have found this from the "after" screenshots alone. It is the reason to do A/B against identical state rather than eyeball the new thing.

## What the spike cost

Three things the API review could not have told us; all three only surfaced by building.

**compileSdk 36 → 37.** The aar declares `minCompileSdk=37`, so 36 fails AAR metadata validation outright. `targetSdk` stays at 36, so runtime behaviour is unchanged.

**minSdk 23 → 24 on the playstore flavour**, as agreed. Drops Android 6.0 for Play Store users, which is a product call.

**R8 needed new rules.** Grafima pulls Compose Multiplatform, which brings `androidx.window` 1.5.0. That reflects against OEM window extensions absent from the SDK, so the release build failed with twelve missing classes until `-dontwarn`s were added.

**Size:** release APK grows 32 KB (+0.3%).

## Verification

- Rendered on device in both debug and **minified release**. Charts draw, no crash, and `AddUseActionCallback.<init>()` is still kept.
- `detekt`, unit tests, and all three release variants clean.
- Instrumented suite 25 of 25.

Two flakes met along the way, neither caused here. `UseIOModuleTest` failed once because my manual CSV import had left rows in the database and the round-trip export carried them; it is not hermetic. `ComposeHitTimerTest :: Reset Timer Test` failed once at the 20s timeout, then passed three consecutive runs.

## What this does not answer

`AllTimeGraph` still has no equivalent for its 5-day sliding window, and the Stats charts need background bands emulated the way MPAndroidChart does today. This spike says the withdrawal charts are ready; it says nothing about the other four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167SJeKBmjmzhj9gNWcZYfs
